### PR TITLE
Refactor node names according to neo4j style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Then enter your query in the top input field.
 
 For example, this finds the IXPs and corresponding country codes where IIJ (AS2497) is:
 ```cypher
-MATCH (iij:AS {asn:2497})-[:MEMBER_OF]-(ix:IXP)--(cc:COUNTRY)
+MATCH (iij:AS {asn:2497})-[:MEMBER_OF]-(ix:IXP)--(cc:Country)
 RETURN iij, ix, cc
 ```
 ![Countries of IXPs where AS2497 is present](/documentation/assets/gallery/as2497ixpCountry.svg)

--- a/documentation/cn.md
+++ b/documentation/cn.md
@@ -16,12 +16,12 @@ Interesting links:
 ## General stats:
 Number ASNs registered in China/HK:
 ```
-match (a:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country)
-where cc.country_code = 'CN' or cc.country_code = 'HK'
-return cc.country_code, count(distinct a)
+MATCH (a:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country)
+WHERE cc.country_code = 'CN' OR cc.country_code = 'HK'
+RETURN cc.country_code, count(DISTINCT a)
 ```
 ╒═════════════════╤═══════════════════╕
-│"cc.country_code"│"count(distinct a)"│
+│"cc.country_code"│"count(DISTINCT a)"│
 ╞═════════════════╪═══════════════════╡
 │"CN"             │6508               │
 ├─────────────────┼───────────────────┤
@@ -30,12 +30,12 @@ return cc.country_code, count(distinct a)
 
 Number chinese/HK ASNs that are active:
 ```
-match (a:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country), (a)-[:ORIGINATE]-(:Prefix)
-where cc.country_code = 'CN' or cc.country_code = 'HK'
-return cc, count(distinct a)
+MATCH (a:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country), (a)-[:ORIGINATE]-(:Prefix)
+WHERE cc.country_code = 'CN' OR cc.country_code = 'HK'
+RETURN cc, count(DISTINCT a)
 ```
 ╒═════════════════════╤═══════════════════╕
-│"cc"                 │"count(distinct a)"│
+│"cc"                 │"count(DISTINCT a)"│
 ╞═════════════════════╪═══════════════════╡
 │{"country_code":"CN"}│5071               │
 ├─────────────────────┼───────────────────┤
@@ -44,28 +44,28 @@ return cc, count(distinct a)
 
 Facilities for CT (4134, 23764):
 ```
-match (a:AS)--(fac:Facility)
-where a.asn in [4134, 23764]
-return a, fac
+MATCH (a:AS)--(fac:Facility)
+WHERE a.asn IN [4134, 23764]
+RETURN a, fac
 ```
 
 Country codes for these facilities:
 ```
-match (a:AS)--(fac:Facility)--(cc:Country)
-where a.asn in [4134, 23764]
-return distinct cc.country_code
+MATCH (a:AS)--(fac:Facility)--(cc:Country)
+WHERE a.asn IN [4134, 23764]
+RETURN DISTINCT cc.country_code
 ```
 
 Country codes for all AS registered for the opaque ID:
 ```
-match (a:AS)-[:ASSIGNED]-(oid:OpaqueID)
-where a.asn in [4134, 23764]
-with oid
-match (oid)--(other:AS)--(fac:Facility)--(cc:Country)
-return distinct cc.country_code, collect(distinct other.asn)
+MATCH (a:AS)-[:ASSIGNED]-(oid:OpaqueID)
+WHERE a.asn IN [4134, 23764]
+WITH oid
+MATCH (oid)--(other:AS)--(fac:Facility)--(cc:Country)
+RETURN DISTINCT cc.country_code, collect(DISTINCT other.asn)
 ```
 ╒═════════════════╤═════════════════════════════╕
-│"cc.country_code"│"collect(distinct other.asn)"│
+│"cc.country_code"│"collect(DISTINCT other.asn)"│
 ╞═════════════════╪═════════════════════════════╡
 │"SG"             │[131285,23764]               │
 ├─────────────────┼─────────────────────────────┤
@@ -97,23 +97,23 @@ return distinct cc.country_code, collect(distinct other.asn)
 ## Co-location facilities 
 Facilities in china/hong-kong:
 ```
-match (c:Country)--(f:Facility)--(a:AS)
-where c.country_code = 'CN' or c.country_code = 'HK'
-return f, count(distinct a) as nb_as order by nb_as desc
+MATCH (c:Country)--(f:Facility)--(a:AS)
+WHERE c.country_code = 'CN' OR c.country_code = 'HK'
+RETURN f, count(DISTINCT a) AS nb_as ORDER BY nb_as DESC
 ```
 
 Facilities where Chinese ASes are (28):
 ```
 MATCH (net_country:Country)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:LOCATED_IN]-(fac:Facility)--(fac_country:Country)
 WHERE net_country.country_code = 'CN'
-RETURN fac_country.country_code, count(distinct net) as nb_AS order by nb_AS desc
+RETURN fac_country.country_code, count(DISTINCT net) AS nb_AS ORDER BY nb_AS DESC
 ```
 
 ASes present at the largest number of facilities:
 ```
 MATCH (net_country:Country)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:LOCATED_IN]-(fac:Facility)--(fac_country:Country)
-WHERE net_country.country_code = 'HK' or net_country.country_code = 'CN'
-RETURN net.asn, net_country.country_code, count(distinct fac_country) as nb_fac order by nb_fac desc
+WHERE net_country.country_code = 'HK' OR net_country.country_code = 'CN'
+RETURN net.asn, net_country.country_code, count(DISTINCT fac_country) AS nb_fac ORDER BY nb_fac DESC
 ```
 
 ## Prefix geolocation
@@ -121,21 +121,21 @@ Geolocation of prefixes announced by Chinese ASes (54):
 ```
 MATCH (net_country:Country)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:ORIGINATE]-(pfx:Prefix)-[:COUNTRY {reference_org:'Internet Health Report'}]-(pfx_country:Country)
 WHERE net_country.country_code = 'CN'
-RETURN pfx_country.country_code, count(distinct net) as nb_AS order by nb_AS desc
+RETURN pfx_country.country_code, count(DISTINCT net) AS nb_AS ORDER BY nb_AS DESC
 ```
 
 Geolocation of prefixes announced by HK ASes (81):
 ```
 MATCH (net_country:Country)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:ORIGINATE]-(pfx:Prefix)-[:COUNTRY {reference_org:'Internet Health Report'}]-(pfx_country:Country)
 WHERE net_country.country_code = 'HK'
-RETURN pfx_country.country_code, count(distinct net) as nb_AS order by nb_AS desc
+RETURN pfx_country.country_code, count(DISTINCT net) AS nb_AS ORDER BY nb_AS DESC
 ```
 
 ASes with the largest footprint:
 ```
 MATCH (net_country:Country)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:ORIGINATE]-(pfx:Prefix)--(pfx_country:Country)
-WHERE net_country.country_code = 'HK' or net_country.country_code = 'CN'
-RETURN net.asn, net_country.country_code, count(distinct pfx_country) as nb_pfx order by nb_pfx desc
+WHERE net_country.country_code = 'HK' OR net_country.country_code = 'CN'
+RETURN net.asn, net_country.country_code, count(DISTINCT pfx_country) AS nb_pfx ORDER BY nb_pfx DESC
 ```
 
 ## Tier-1 comparison
@@ -145,13 +145,13 @@ RETURN net.asn, net_country.country_code, count(distinct pfx_country) as nb_pfx 
 Graph (top10k):
 ```
 MATCH (:Ranking)-[r:RANK]-(dn:DomainName)--(ip:IP)--(pfx:Prefix)-[:ORIGINATE]-(net:AS)
-WHERE dn.name ends with '.cn' and r.rank<10000
+WHERE dn.name ENDS WITH '.cn' AND r.rank<10000
 RETURN dn, ip, pfx, net
 ```
 
 Table (top1M):
 ```
 MATCH (:Ranking)-[r:RANK]-(dn:DomainName)--(ip:IP)--(pfx:Prefix)-[:ORIGINATE]-(net:AS)
-WHERE dn.name ends with '.cn' and r.rank<100000
-RETURN net.asn,  count(distinct dn) as nb_domain_name order by nb_domain_name desc
+WHERE dn.name ENDS WITH '.cn' AND r.rank<100000
+RETURN net.asn,  count(DISTINCT dn) AS nb_domain_name ORDER BY nb_domain_name DESC
 ```

--- a/documentation/cn.md
+++ b/documentation/cn.md
@@ -16,7 +16,7 @@ Interesting links:
 ## General stats:
 Number ASNs registered in China/HK:
 ```
-match (a:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:COUNTRY)
+match (a:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country)
 where cc.country_code = 'CN' or cc.country_code = 'HK'
 return cc.country_code, count(distinct a)
 ```
@@ -30,7 +30,7 @@ return cc.country_code, count(distinct a)
 
 Number chinese/HK ASNs that are active:
 ```
-match (a:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:COUNTRY), (a)-[:ORIGINATE]-(:PREFIX)
+match (a:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country), (a)-[:ORIGINATE]-(:Prefix)
 where cc.country_code = 'CN' or cc.country_code = 'HK'
 return cc, count(distinct a)
 ```
@@ -44,24 +44,24 @@ return cc, count(distinct a)
 
 Facilities for CT (4134, 23764):
 ```
-match (a:AS)--(fac:FACILITY) 
+match (a:AS)--(fac:Facility)
 where a.asn in [4134, 23764]
 return a, fac
 ```
 
 Country codes for these facilities:
 ```
-match (a:AS)--(fac:FACILITY)--(cc:COUNTRY) 
+match (a:AS)--(fac:Facility)--(cc:Country)
 where a.asn in [4134, 23764]
 return distinct cc.country_code
 ```
 
 Country codes for all AS registered for the opaque ID:
 ```
-match (a:AS)-[:ASSIGNED]-(oid:OPAQUE_ID)
+match (a:AS)-[:ASSIGNED]-(oid:OpaqueID)
 where a.asn in [4134, 23764]
 with oid
-match (oid)--(other:AS)--(fac:FACILITY)--(cc:COUNTRY) 
+match (oid)--(other:AS)--(fac:Facility)--(cc:Country)
 return distinct cc.country_code, collect(distinct other.asn)
 ```
 ╒═════════════════╤═════════════════════════════╕
@@ -97,21 +97,21 @@ return distinct cc.country_code, collect(distinct other.asn)
 ## Co-location facilities 
 Facilities in china/hong-kong:
 ```
-match (c:COUNTRY)--(f:FACILITY)--(a:AS) 
+match (c:Country)--(f:Facility)--(a:AS)
 where c.country_code = 'CN' or c.country_code = 'HK'
 return f, count(distinct a) as nb_as order by nb_as desc
 ```
 
 Facilities where Chinese ASes are (28):
 ```
-MATCH (net_country:COUNTRY)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:LOCATED_IN]-(fac:FACILITY)--(fac_country:COUNTRY)
+MATCH (net_country:Country)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:LOCATED_IN]-(fac:Facility)--(fac_country:Country)
 WHERE net_country.country_code = 'CN'
 RETURN fac_country.country_code, count(distinct net) as nb_AS order by nb_AS desc
 ```
 
 ASes present at the largest number of facilities:
 ```
-MATCH (net_country:COUNTRY)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:LOCATED_IN]-(fac:FACILITY)--(fac_country:COUNTRY)
+MATCH (net_country:Country)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:LOCATED_IN]-(fac:Facility)--(fac_country:Country)
 WHERE net_country.country_code = 'HK' or net_country.country_code = 'CN'
 RETURN net.asn, net_country.country_code, count(distinct fac_country) as nb_fac order by nb_fac desc
 ```
@@ -119,21 +119,21 @@ RETURN net.asn, net_country.country_code, count(distinct fac_country) as nb_fac 
 ## Prefix geolocation
 Geolocation of prefixes announced by Chinese ASes (54):
 ```
-MATCH (net_country:COUNTRY)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:ORIGINATE]-(pfx:PREFIX)-[:COUNTRY {reference_org:'Internet Health Report'}]-(pfx_country:COUNTRY)
+MATCH (net_country:Country)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:ORIGINATE]-(pfx:Prefix)-[:COUNTRY {reference_org:'Internet Health Report'}]-(pfx_country:Country)
 WHERE net_country.country_code = 'CN'
 RETURN pfx_country.country_code, count(distinct net) as nb_AS order by nb_AS desc
 ```
 
 Geolocation of prefixes announced by HK ASes (81):
 ```
-MATCH (net_country:COUNTRY)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:ORIGINATE]-(pfx:PREFIX)-[:COUNTRY {reference_org:'Internet Health Report'}]-(pfx_country:COUNTRY)
+MATCH (net_country:Country)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:ORIGINATE]-(pfx:Prefix)-[:COUNTRY {reference_org:'Internet Health Report'}]-(pfx_country:Country)
 WHERE net_country.country_code = 'HK'
 RETURN pfx_country.country_code, count(distinct net) as nb_AS order by nb_AS desc
 ```
 
 ASes with the largest footprint:
 ```
-MATCH (net_country:COUNTRY)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:ORIGINATE]-(pfx:PREFIX)--(pfx_country:COUNTRY)
+MATCH (net_country:Country)-[:COUNTRY {reference_org:'NRO'}]-(net:AS)-[:ORIGINATE]-(pfx:Prefix)--(pfx_country:Country)
 WHERE net_country.country_code = 'HK' or net_country.country_code = 'CN'
 RETURN net.asn, net_country.country_code, count(distinct pfx_country) as nb_pfx order by nb_pfx desc
 ```
@@ -144,14 +144,14 @@ RETURN net.asn, net_country.country_code, count(distinct pfx_country) as nb_pfx 
 ## Domain name distribution
 Graph (top10k):
 ```
-MATCH (:RANKING)-[r:RANK]-(dn:DOMAIN_NAME)--(ip:IP)--(pfx:PREFIX)-[:ORIGINATE]-(net:AS)
+MATCH (:Ranking)-[r:RANK]-(dn:DomainName)--(ip:IP)--(pfx:Prefix)-[:ORIGINATE]-(net:AS)
 WHERE dn.name ends with '.cn' and r.rank<10000
 RETURN dn, ip, pfx, net
 ```
 
 Table (top1M):
 ```
-MATCH (:RANKING)-[r:RANK]-(dn:DOMAIN_NAME)--(ip:IP)--(pfx:PREFIX)-[:ORIGINATE]-(net:AS)
+MATCH (:Ranking)-[r:RANK]-(dn:DomainName)--(ip:IP)--(pfx:Prefix)-[:ORIGINATE]-(net:AS)
 WHERE dn.name ends with '.cn' and r.rank<100000
 RETURN net.asn,  count(distinct dn) as nb_domain_name order by nb_domain_name desc
 ```

--- a/documentation/gallery.md
+++ b/documentation/gallery.md
@@ -68,7 +68,7 @@ From the top 10k domain names select domain names that ends with '.jp', the
 corresponding IP, prefix, and ASN.
 ```cypher
 MATCH (:Ranking)-[r:RANK]-(dn:DomainName)--(ip:IP)--(pfx:Prefix)-[:ORIGINATE]-(net:AS)
-WHERE dn.name ends with '.jp' and r.rank<10000
+WHERE dn.name ENDS WITH '.jp' AND r.rank<10000
 RETURN dn, ip, pfx, net
 ```
 ![ASes hosting top domain names in Japan](/documentation/assets/gallery/top10kJapanAS.svg)

--- a/documentation/gallery.md
+++ b/documentation/gallery.md
@@ -15,9 +15,9 @@ Below are examples queries that you can copy/paste in Neo4j browser:
 
 
 ### Names for AS2497
-Find 'NAME' nodes directly connected to the node corresponding to AS2497.
+Find 'Name' nodes directly connected to the node corresponding to AS2497.
 ```cypher
-MATCH (a:AS {asn:2497})--(n:NAME) RETURN a,n
+MATCH (a:AS {asn:2497})--(n:Name) RETURN a,n
 ```
 ![Names for AS2497](/documentation/assets/gallery/as2497names.svg)
 
@@ -26,7 +26,7 @@ MATCH (a:AS {asn:2497})--(n:NAME) RETURN a,n
 Find nodes of any type that are connected to the node corresponding to prefix 
 8.8.8.0/24.
 ```cypher
-MATCH (gdns:PREFIX {prefix:'8.8.8.0/24'})--(neighbor) 
+MATCH (gdns:Prefix {prefix:'8.8.8.0/24'})--(neighbor)
 RETURN gdns, neighbor
 ```
 ![All nodes related to 8.8.8.0/24](/documentation/assets/gallery/prefixAllRelated.svg)
@@ -36,7 +36,7 @@ RETURN gdns, neighbor
 Here we search for a country node directly connected to AS2497's node and that
 comes from NRO's delegated stats.
 ```cypher
-MATCH (iij:AS {asn:2497})-[{reference_name:'nro.delegated_stats'}]-(cc:COUNTRY) 
+MATCH (iij:AS {asn:2497})-[{reference_name:'nro.delegated_stats'}]-(cc:Country)
 RETURN iij, cc
 ```
 ![Country code of AS2497 in delegated files](/documentation/assets/gallery/as2497country.svg)
@@ -46,7 +46,7 @@ RETURN iij, cc
 Starting from the node corresponding to AS2497, find IXPs where AS2497 is member
 of, and then the country corresponding to each IXP.
 ```cypher
-MATCH (iij:AS {asn:2497})-[:MEMBER_OF]-(ix:IXP)--(cc:COUNTRY) 
+MATCH (iij:AS {asn:2497})-[:MEMBER_OF]-(ix:IXP)--(cc:Country)
 RETURN iij, ix, cc
 ```
 ![Countries of IXPs where AS2497 is present](/documentation/assets/gallery/as2497ixpCountry.svg)
@@ -56,7 +56,7 @@ RETURN iij, ix, cc
 Select domain names in top 50k rankings that resolves to an IP originated by
 AS2497.
 ```cypher
-MATCH (:RANKING)-[r:RANK]-(dn:DOMAIN_NAME)--(ip:IP)--(pfx:PREFIX)-[:ORIGINATE]-(iij:AS {asn:2497})
+MATCH (:Ranking)-[r:RANK]-(dn:DomainName)--(ip:IP)--(pfx:Prefix)-[:ORIGINATE]-(iij:AS {asn:2497})
 WHERE r.rank < 50000
 RETURN dn, ip, pfx, iij
 ```
@@ -67,7 +67,7 @@ RETURN dn, ip, pfx, iij
 From the top 10k domain names select domain names that ends with '.jp', the
 corresponding IP, prefix, and ASN.
 ```cypher
-MATCH (:RANKING)-[r:RANK]-(dn:DOMAIN_NAME)--(ip:IP)--(pfx:PREFIX)-[:ORIGINATE]-(net:AS)
+MATCH (:Ranking)-[r:RANK]-(dn:DomainName)--(ip:IP)--(pfx:Prefix)-[:ORIGINATE]-(net:AS)
 WHERE dn.name ends with '.jp' and r.rank<10000
 RETURN dn, ip, pfx, net
 ```

--- a/documentation/iij.md
+++ b/documentation/iij.md
@@ -3,60 +3,60 @@
 ## IIJ's geographical footprint
 #### IXP where IIJ is present
 ```cypher
-MATCH (iij:AS {asn:2497})-[:MEMBER_OF]-(ix:IXP)--(cc:Country) return iij, ix, cc
+MATCH (iij:AS {asn:2497})-[:MEMBER_OF]-(ix:IXP)--(cc:Country) RETURN iij, ix, cc
 ```
 
 ### Facilities where IIJ is present
 ```cypher
-MATCH (iij:AS {asn:2497})--(ix:Facility)--(cc:Country) return iij, ix, cc
+MATCH (iij:AS {asn:2497})--(ix:Facility)--(cc:Country) RETURN iij, ix, cc
 ```
 
 #### Geolocation of prefixes announced by IIJ
 ```cypher
-MATCH (iij:AS {asn:2497})-[:ORIGINATE]-(pfx:Prefix)--(cc:Country) return iij, pfx, cc
+MATCH (iij:AS {asn:2497})-[:ORIGINATE]-(pfx:Prefix)--(cc:Country) RETURN iij, pfx, cc
 ```
 
 #### Geolocation of prefixes announced by IIJ's customer
 graph:
 ```cypher
-MATCH (iij:AS {asn:2497})<-[:DEPENDS_ON]-(customer:AS)-[:ORIGINATE]-(pfx:Prefix)--(cc:Country) return iij, customer, pfx, cc
+MATCH (iij:AS {asn:2497})<-[:DEPENDS_ON]-(customer:AS)-[:ORIGINATE]-(pfx:Prefix)--(cc:Country) RETURN iij, customer, pfx, cc
 ```
 table:
 ```cypher
 MATCH (iij:AS {asn:2497})<-[dep:DEPENDS_ON]-(customer:AS)-[:ORIGINATE]-(pfx:Prefix)--(cc:Country)
-RETURN cc.country_code, count(distinct customer) as nb_dep order by nb_dep desc
+RETURN cc.country_code, count(DISTINCT customer) AS nb_dep ORDER BY nb_dep DESC
 ```
 
 ## IIJ's logical (DNS) footprint
 ### Top domain names that map to prefixes originated from AS2497 
 ```cypher
-match (n:AS {asn:2497})-[:ORIGINATE]-(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking) where r.rank<10000 return n,p,i,d
+MATCH (n:AS {asn:2497})-[:ORIGINATE]-(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking) WHERE r.rank<10000 RETURN n,p,i,d
 ```
 
 ### Top domain names that are related to AS2497 (including domains that map to prefixes orginated by AS2497 and prefixes that depends on AS2497)
 ```cypher
-match (n:AS {asn:2497})--(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking) where r.rank<10000 return n,p,i,d
+MATCH (n:AS {asn:2497})--(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking) WHERE r.rank<10000 RETURN n,p,i,d
 ```
 
 ## IIJ's main competitors
 ```cypher
-match (comp:AS)-[:PEERS_WITH {rel:1}]->(customer:AS)<-[:PEERS_WITH {rel:1}]-(iij:AS {asn:2497})
+MATCH (comp:AS)-[:PEERS_WITH {rel:1}]->(customer:AS)<-[:PEERS_WITH {rel:1}]-(iij:AS {asn:2497})
 WITH comp, customer OPTIONAL MATCH (comp)-[:NAME {reference_org:'RIPE NCC'}]-(comp_name:Name)
-return comp, comp_name, count(distinct customer) as nb_customer order by nb_customer desc
+RETURN comp, comp_name, count(DISTINCT customer) AS nb_customer ORDER BY nb_customer DESC
 ```
 
 ## Top Japanese domains
 Graph:
 ```cypher
 MATCH (:Ranking)-[r:RANK]-(dn:DomainName)--(ip:IP)--(pfx:Prefix)-[:ORIGINATE]-(net:AS)
-WHERE dn.name ends with '.jp' and r.rank<10000
+WHERE dn.name ENDS WITH '.jp' AND r.rank<10000
 RETURN dn, ip, pfx, net
 ```
 
 Table:
 ```cypher
 MATCH (:Ranking)-[r:RANK]-(dn:DomainName)--(ip:IP)--(pfx:Prefix)-[:ORIGINATE]-(net:AS)
-WHERE dn.name ends with '.jp' and r.rank<100000
+WHERE dn.name ENDS WITH '.jp' AND r.rank<100000
 WITH net, dn  OPTIONAL MATCH (net:AS)-[:NAME {reference_org:'RIPE NCC'}]-(net_name:Name)
-RETURN net.asn, net_name.name, count(distinct dn) as nb_domain_name order by nb_domain_name desc
+RETURN net.asn, net_name.name, count(DISTINCT dn) AS nb_domain_name ORDER BY nb_domain_name DESC
 ```

--- a/documentation/iij.md
+++ b/documentation/iij.md
@@ -3,60 +3,60 @@
 ## IIJ's geographical footprint
 #### IXP where IIJ is present
 ```cypher
-MATCH (iij:AS {asn:2497})-[:MEMBER_OF]-(ix:IXP)--(cc:COUNTRY) return iij, ix, cc
+MATCH (iij:AS {asn:2497})-[:MEMBER_OF]-(ix:IXP)--(cc:Country) return iij, ix, cc
 ```
 
 ### Facilities where IIJ is present
 ```cypher
-MATCH (iij:AS {asn:2497})--(ix:FACILITY)--(cc:COUNTRY) return iij, ix, cc
+MATCH (iij:AS {asn:2497})--(ix:Facility)--(cc:Country) return iij, ix, cc
 ```
 
 #### Geolocation of prefixes announced by IIJ
 ```cypher
-MATCH (iij:AS {asn:2497})-[:ORIGINATE]-(pfx:PREFIX)--(cc:COUNTRY) return iij, pfx, cc
+MATCH (iij:AS {asn:2497})-[:ORIGINATE]-(pfx:Prefix)--(cc:Country) return iij, pfx, cc
 ```
 
 #### Geolocation of prefixes announced by IIJ's customer
 graph:
 ```cypher
-MATCH (iij:AS {asn:2497})<-[:DEPENDS_ON]-(customer:AS)-[:ORIGINATE]-(pfx:PREFIX)--(cc:COUNTRY) return iij, customer, pfx, cc
+MATCH (iij:AS {asn:2497})<-[:DEPENDS_ON]-(customer:AS)-[:ORIGINATE]-(pfx:Prefix)--(cc:Country) return iij, customer, pfx, cc
 ```
 table:
 ```cypher
-MATCH (iij:AS {asn:2497})<-[dep:DEPENDS_ON]-(customer:AS)-[:ORIGINATE]-(pfx:PREFIX)--(cc:COUNTRY) 
+MATCH (iij:AS {asn:2497})<-[dep:DEPENDS_ON]-(customer:AS)-[:ORIGINATE]-(pfx:Prefix)--(cc:Country)
 RETURN cc.country_code, count(distinct customer) as nb_dep order by nb_dep desc
 ```
 
 ## IIJ's logical (DNS) footprint
 ### Top domain names that map to prefixes originated from AS2497 
 ```cypher
-match (n:AS {asn:2497})-[:ORIGINATE]-(p:PREFIX)--(i:IP)--(d:DOMAIN_NAME)-[r:RANK]-(:RANKING) where r.rank<10000 return n,p,i,d
+match (n:AS {asn:2497})-[:ORIGINATE]-(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking) where r.rank<10000 return n,p,i,d
 ```
 
 ### Top domain names that are related to AS2497 (including domains that map to prefixes orginated by AS2497 and prefixes that depends on AS2497)
 ```cypher
-match (n:AS {asn:2497})--(p:PREFIX)--(i:IP)--(d:DOMAIN_NAME)-[r:RANK]-(:RANKING) where r.rank<10000 return n,p,i,d
+match (n:AS {asn:2497})--(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking) where r.rank<10000 return n,p,i,d
 ```
 
 ## IIJ's main competitors
 ```cypher
 match (comp:AS)-[:PEERS_WITH {rel:1}]->(customer:AS)<-[:PEERS_WITH {rel:1}]-(iij:AS {asn:2497})
-WITH comp, customer OPTIONAL MATCH (comp)-[:NAME {reference_org:'RIPE NCC'}]-(comp_name:NAME)
+WITH comp, customer OPTIONAL MATCH (comp)-[:NAME {reference_org:'RIPE NCC'}]-(comp_name:Name)
 return comp, comp_name, count(distinct customer) as nb_customer order by nb_customer desc
 ```
 
 ## Top Japanese domains
 Graph:
 ```cypher
-MATCH (:RANKING)-[r:RANK]-(dn:DOMAIN_NAME)--(ip:IP)--(pfx:PREFIX)-[:ORIGINATE]-(net:AS)
+MATCH (:Ranking)-[r:RANK]-(dn:DomainName)--(ip:IP)--(pfx:Prefix)-[:ORIGINATE]-(net:AS)
 WHERE dn.name ends with '.jp' and r.rank<10000
 RETURN dn, ip, pfx, net
 ```
 
 Table:
 ```cypher
-MATCH (:RANKING)-[r:RANK]-(dn:DOMAIN_NAME)--(ip:IP)--(pfx:PREFIX)-[:ORIGINATE]-(net:AS)
+MATCH (:Ranking)-[r:RANK]-(dn:DomainName)--(ip:IP)--(pfx:Prefix)-[:ORIGINATE]-(net:AS)
 WHERE dn.name ends with '.jp' and r.rank<100000
-WITH net, dn  OPTIONAL MATCH (net:AS)-[:NAME {reference_org:'RIPE NCC'}]-(net_name:NAME)
+WITH net, dn  OPTIONAL MATCH (net:AS)-[:NAME {reference_org:'RIPE NCC'}]-(net_name:Name)
 RETURN net.asn, net_name.name, count(distinct dn) as nb_domain_name order by nb_domain_name desc
 ```

--- a/documentation/ua_ru.md
+++ b/documentation/ua_ru.md
@@ -11,13 +11,13 @@
 
 
 ## Find all nodes that have the word 'crimea' in their name
-match (x)--(n:NAME) WHERE toLower(n.name) contains 'crimea' RETURN  x, n;
+match (x)--(n:Name) WHERE toLower(n.name) contains 'crimea' RETURN  x, n;
 
 ## Crimean neighbors network dependencies
-match (crimea:NAME)--(:AS)-[:PEERS_WITH]-(neighbors:AS)-[r:DEPENDS_ON]-(transit_as:AS)--(transit_name:NAME) where toLower(crimea.name) contains 'crimea' and toFloat(r.hegemony)>0.2 return transit_as, collect(distinct transit_name.name), count(distinct r) as nb_links order by nb_links desc;
+match (crimea:Name)--(:AS)-[:PEERS_WITH]-(neighbors:AS)-[r:DEPENDS_ON]-(transit_as:AS)--(transit_name:Name) where toLower(crimea.name) contains 'crimea' and toFloat(r.hegemony)>0.2 return transit_as, collect(distinct transit_name.name), count(distinct r) as nb_links order by nb_links desc;
 
 ## Crimean IXP members dependencies
-match (crimea:NAME)--(:IXP)-[:MEMBER_OF]-(neighbors:AS)-[r:DEPENDS_ON]-(transit_as:AS)--(transit_name:NAME) where toLower(crimea.name) contains 'crimea' and toFloat(r.hegemony)>0.2 return transit_as, collect(distinct transit_name.name), count(distinct r) as nb_links order by nb_links desc;
+match (crimea:Name)--(:IXP)-[:MEMBER_OF]-(neighbors:AS)-[r:DEPENDS_ON]-(transit_as:AS)--(transit_name:Name) where toLower(crimea.name) contains 'crimea' and toFloat(r.hegemony)>0.2 return transit_as, collect(distinct transit_name.name), count(distinct r) as nb_links order by nb_links desc;
 
 ## who is at Crimea ixp but not any other ixp
 
@@ -26,12 +26,12 @@ match (crimea:NAME)--(:IXP)-[:MEMBER_OF]-(neighbors:AS)-[r:DEPENDS_ON]-(transit_
 
 ## Top domain names that are hosted by Rostelecom
 ```
-match (n:AS {asn:12389})-[:ORIGINATE]-(p:PREFIX)--(i:IP)--(d:DOMAIN_NAME)-[r:RANK]-(:RANKING) where r.rank<1000 return n,p,i,d
+match (n:AS {asn:12389})-[:ORIGINATE]-(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking) where r.rank<1000 return n,p,i,d
 ```
 
 ## Top domain names that depends on Rostelecom
 ```
-match (n:AS {asn:12389})--(p:PREFIX)--(i:IP)--(d:DOMAIN_NAME)-[r:RANK]-(:RANKING) where r.rank<1000 return n,p,i,d
+match (n:AS {asn:12389})--(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking) where r.rank<1000 return n,p,i,d
 ```
 
 ## all ases assigned to same org
@@ -39,34 +39,34 @@ match (n:AS {asn:12389})--(p:PREFIX)--(i:IP)--(d:DOMAIN_NAME)-[r:RANK]-(:RANKING
 
 ## which top domain names map to this ASes
 ```
-match (oid:OPAQUE_ID)--(net:AS)--(pfx:PREFIX)--(ip:IP)--(dname:DOMAIN_NAME)-[r]-(:RANKING), (net)-[{reference_org:'RIPE NCC'}]-(asname:NAME) where (oid:OPAQUE_ID)--(:AS {asn:12389}) and r.rank < 10000 and net.asn<>12389 return net, pfx, ip, dname, asname
+match (oid:OpaqueID)--(net:AS)--(pfx:Prefix)--(ip:IP)--(dname:DomainName)-[r]-(:Ranking), (net)-[{reference_org:'RIPE NCC'}]-(asname:Name) where (oid:OpaqueID)--(:AS {asn:12389}) and r.rank < 10000 and net.asn<>12389 return net, pfx, ip, dname, asname
 ```
 
 ## which prefixes map to other counties
 ```
-match (:AS {asn:12389})--(oid:OPAQUE_ID)--(net:AS)--(pfx:PREFIX)--(cc:COUNTRY), (net)-[{reference_org:'RIPE NCC'}]-(asname:NAME) where net.asn<>12389 and cc.country_code <> 'RU' return net, pfx, asname, cc, oid
+match (:AS {asn:12389})--(oid:OpaqueID)--(net:AS)--(pfx:Prefix)--(cc:Country), (net)-[{reference_org:'RIPE NCC'}]-(asname:Name) where net.asn<>12389 and cc.country_code <> 'RU' return net, pfx, asname, cc, oid
 ```
 
 ## which IXPs they are member of:
 ```
-match (oid:OPAQUE_ID)--(n:AS)--(ix:IXP) where (oid:OPAQUE_ID)--(:AS {asn:12389}) return n, ix
+match (oid:OpaqueID)--(n:AS)--(ix:IXP) where (oid:OpaqueID)--(:AS {asn:12389}) return n, ix
 ```
 
 ## which IXPs are they operating to?
 ```
-match (n:AS {asn:12389})--(ix:IXP)--(cc:COUNTRY) return n,ix,cc
+match (n:AS {asn:12389})--(ix:IXP)--(cc:Country) return n,ix,cc
 ```
 
 ## prefixes assigned to this org and ASes announcing it
 
 !
 ## Country code of ASes hosting top domain names
-match (:RANKING)-[r:RANK]-(domain:DOMAIN_NAME)--(:IP)--(:PREFIX)-[:ORIGINATE]-(:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:COUNTRY) where r.rank<10000 and domain.name ends with '.ru' return cc.country_code, count(distinct domain.name) as dm_count ORDER BY dm_count DESC
-match (:RANKING)-[r:RANK]-(domain:DOMAIN_NAME)--(:IP)--(:PREFIX)-[:ORIGINATE]-(:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:COUNTRY) where r.rank<10000 and domain.name ends with '.jp' return cc.country_code, count(distinct domain.name) as dm_count ORDER BY dm_count DESC
-match (:RANKING)-[r:RANK]-(domain:DOMAIN_NAME)--(:IP)--(:PREFIX)-[:ORIGINATE]-(:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:COUNTRY) where r.rank<10000 and domain.name ends with '.jp' return cc.country_code, count(distinct domain.name) as dm_count ORDER BY dm_count DESC
+match (:Ranking)-[r:RANK]-(domain:DomainName)--(:IP)--(:Prefix)-[:ORIGINATE]-(:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country) where r.rank<10000 and domain.name ends with '.ru' return cc.country_code, count(distinct domain.name) as dm_count ORDER BY dm_count DESC
+match (:Ranking)-[r:RANK]-(domain:DomainName)--(:IP)--(:Prefix)-[:ORIGINATE]-(:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country) where r.rank<10000 and domain.name ends with '.jp' return cc.country_code, count(distinct domain.name) as dm_count ORDER BY dm_count DESC
+match (:Ranking)-[r:RANK]-(domain:DomainName)--(:IP)--(:Prefix)-[:ORIGINATE]-(:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country) where r.rank<10000 and domain.name ends with '.jp' return cc.country_code, count(distinct domain.name) as dm_count ORDER BY dm_count DESC
 
 # Interesting queries:
 ## Orange presence
 ```
-match (oid)--(n:AS)--(ix:IXP)--(cc:COUNTRY) where (oid:OPAQUE_ID)--(:AS {asn:5511}) return n,ix,cc
+match (oid)--(n:AS)--(ix:IXP)--(cc:Country) where (oid:OpaqueID)--(:AS {asn:5511}) return n,ix,cc
 ```

--- a/documentation/ua_ru.md
+++ b/documentation/ua_ru.md
@@ -11,13 +11,13 @@
 
 
 ## Find all nodes that have the word 'crimea' in their name
-match (x)--(n:Name) WHERE toLower(n.name) contains 'crimea' RETURN  x, n;
+MATCH (x)--(n:Name) WHERE toLower(n.name) CONTAINS 'crimea' RETURN  x, n;
 
 ## Crimean neighbors network dependencies
-match (crimea:Name)--(:AS)-[:PEERS_WITH]-(neighbors:AS)-[r:DEPENDS_ON]-(transit_as:AS)--(transit_name:Name) where toLower(crimea.name) contains 'crimea' and toFloat(r.hegemony)>0.2 return transit_as, collect(distinct transit_name.name), count(distinct r) as nb_links order by nb_links desc;
+MATCH (crimea:Name)--(:AS)-[:PEERS_WITH]-(neighbors:AS)-[r:DEPENDS_ON]-(transit_as:AS)--(transit_name:Name) WHERE toLower(crimea.name) CONTAINS 'crimea' AND toFloat(r.hegemony)>0.2 RETURN transit_as, collect(DISTINCT transit_name.name), count(DISTINCT r) AS nb_links ORDER BY nb_links DESC;
 
 ## Crimean IXP members dependencies
-match (crimea:Name)--(:IXP)-[:MEMBER_OF]-(neighbors:AS)-[r:DEPENDS_ON]-(transit_as:AS)--(transit_name:Name) where toLower(crimea.name) contains 'crimea' and toFloat(r.hegemony)>0.2 return transit_as, collect(distinct transit_name.name), count(distinct r) as nb_links order by nb_links desc;
+MATCH (crimea:Name)--(:IXP)-[:MEMBER_OF]-(neighbors:AS)-[r:DEPENDS_ON]-(transit_as:AS)--(transit_name:Name) WHERE toLower(crimea.name) CONTAINS 'crimea' AND toFloat(r.hegemony)>0.2 RETURN transit_as, collect(DISTINCT transit_name.name), count(DISTINCT r) AS nb_links ORDER BY nb_links DESC;
 
 ## who is at Crimea ixp but not any other ixp
 
@@ -26,12 +26,12 @@ match (crimea:Name)--(:IXP)-[:MEMBER_OF]-(neighbors:AS)-[r:DEPENDS_ON]-(transit_
 
 ## Top domain names that are hosted by Rostelecom
 ```
-match (n:AS {asn:12389})-[:ORIGINATE]-(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking) where r.rank<1000 return n,p,i,d
+MATCH (n:AS {asn:12389})-[:ORIGINATE]-(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking) WHERE r.rank<1000 RETURN n,p,i,d
 ```
 
 ## Top domain names that depends on Rostelecom
 ```
-match (n:AS {asn:12389})--(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking) where r.rank<1000 return n,p,i,d
+MATCH (n:AS {asn:12389})--(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking) WHERE r.rank<1000 RETURN n,p,i,d
 ```
 
 ## all ases assigned to same org
@@ -39,34 +39,34 @@ match (n:AS {asn:12389})--(p:Prefix)--(i:IP)--(d:DomainName)-[r:RANK]-(:Ranking)
 
 ## which top domain names map to this ASes
 ```
-match (oid:OpaqueID)--(net:AS)--(pfx:Prefix)--(ip:IP)--(dname:DomainName)-[r]-(:Ranking), (net)-[{reference_org:'RIPE NCC'}]-(asname:Name) where (oid:OpaqueID)--(:AS {asn:12389}) and r.rank < 10000 and net.asn<>12389 return net, pfx, ip, dname, asname
+MATCH (oid:OpaqueID)--(net:AS)--(pfx:Prefix)--(ip:IP)--(dname:DomainName)-[r]-(:Ranking), (net)-[{reference_org:'RIPE NCC'}]-(asname:Name) WHERE (oid:OpaqueID)--(:AS {asn:12389}) AND r.rank < 10000 AND net.asn<>12389 RETURN net, pfx, ip, dname, asname
 ```
 
 ## which prefixes map to other counties
 ```
-match (:AS {asn:12389})--(oid:OpaqueID)--(net:AS)--(pfx:Prefix)--(cc:Country), (net)-[{reference_org:'RIPE NCC'}]-(asname:Name) where net.asn<>12389 and cc.country_code <> 'RU' return net, pfx, asname, cc, oid
+MATCH (:AS {asn:12389})--(oid:OpaqueID)--(net:AS)--(pfx:Prefix)--(cc:Country), (net)-[{reference_org:'RIPE NCC'}]-(asname:Name) WHERE net.asn<>12389 AND cc.country_code <> 'RU' RETURN net, pfx, asname, cc, oid
 ```
 
 ## which IXPs they are member of:
 ```
-match (oid:OpaqueID)--(n:AS)--(ix:IXP) where (oid:OpaqueID)--(:AS {asn:12389}) return n, ix
+MATCH (oid:OpaqueID)--(n:AS)--(ix:IXP) WHERE (oid:OpaqueID)--(:AS {asn:12389}) RETURN n, ix
 ```
 
 ## which IXPs are they operating to?
 ```
-match (n:AS {asn:12389})--(ix:IXP)--(cc:Country) return n,ix,cc
+MATCH (n:AS {asn:12389})--(ix:IXP)--(cc:Country) RETURN n,ix,cc
 ```
 
 ## prefixes assigned to this org and ASes announcing it
 
 !
 ## Country code of ASes hosting top domain names
-match (:Ranking)-[r:RANK]-(domain:DomainName)--(:IP)--(:Prefix)-[:ORIGINATE]-(:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country) where r.rank<10000 and domain.name ends with '.ru' return cc.country_code, count(distinct domain.name) as dm_count ORDER BY dm_count DESC
-match (:Ranking)-[r:RANK]-(domain:DomainName)--(:IP)--(:Prefix)-[:ORIGINATE]-(:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country) where r.rank<10000 and domain.name ends with '.jp' return cc.country_code, count(distinct domain.name) as dm_count ORDER BY dm_count DESC
-match (:Ranking)-[r:RANK]-(domain:DomainName)--(:IP)--(:Prefix)-[:ORIGINATE]-(:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country) where r.rank<10000 and domain.name ends with '.jp' return cc.country_code, count(distinct domain.name) as dm_count ORDER BY dm_count DESC
+MATCH (:Ranking)-[r:RANK]-(domain:DomainName)--(:IP)--(:Prefix)-[:ORIGINATE]-(:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country) WHERE r.rank<10000 AND domain.name ENDS WITH '.ru' RETURN cc.country_code, count(DISTINCT domain.name) AS dm_count ORDER BY dm_count DESC
+MATCH (:Ranking)-[r:RANK]-(domain:DomainName)--(:IP)--(:Prefix)-[:ORIGINATE]-(:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country) WHERE r.rank<10000 AND domain.name ENDS WITH '.jp' RETURN cc.country_code, count(DISTINCT domain.name) AS dm_count ORDER BY dm_count DESC
+MATCH (:Ranking)-[r:RANK]-(domain:DomainName)--(:IP)--(:Prefix)-[:ORIGINATE]-(:AS)-[:COUNTRY {reference_org:'NRO'}]-(cc:Country) WHERE r.rank<10000 AND domain.name ENDS WITH '.jp' RETURN cc.country_code, count(DISTINCT domain.name) AS dm_count ORDER BY dm_count DESC
 
 # Interesting queries:
 ## Orange presence
 ```
-match (oid)--(n:AS)--(ix:IXP)--(cc:Country) where (oid:OpaqueID)--(:AS {asn:5511}) return n,ix,cc
+MATCH (oid)--(n:AS)--(ix:IXP)--(cc:Country) WHERE (oid:OpaqueID)--(:AS {asn:5511}) RETURN n,ix,cc
 ```

--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -35,7 +35,7 @@ NODE_CONSTRAINTS = {
 
 # Properties that may be frequently queried and that are not constraints
 NODE_INDEXES = {
-        'PeeringDBOrgID': [ 'id' ]
+        'PeeringdbOrgID': [ 'id' ]
         }
 
 # Set of node labels with constrains (ease search for node merging)

--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -161,14 +161,14 @@ class IYP(object):
        """
 
         if all:
-            existing_nodes = self.tx.run(f"MATCH (n:{type}) RETURN n.{prop_name} as {prop_name}, ID(n) as _id")
+            existing_nodes = self.tx.run(f"MATCH (n:{type}) RETURN n.{prop_name} AS {prop_name}, ID(n) AS _id")
         else:
             list_prop = list(prop_set)
             existing_nodes = self.tx.run(f"""
-            WITH $list_prop as list_prop
+            WITH $list_prop AS list_prop
             MATCH (n:{type}) 
             WHERE n.{prop_name} IN list_prop
-            RETURN n.{prop_name} as {prop_name}, ID(n) as _id""", list_prop=list_prop)
+            RETURN n.{prop_name} AS {prop_name}, ID(n) AS _id""", list_prop=list_prop)
 
         ids = {node[prop_name]: node['_id'] for node in existing_nodes }
         existing_nodes_set = set(ids.keys())
@@ -179,9 +179,9 @@ class IYP(object):
         for i in range(0, len(missing_nodes), BATCH_SIZE):
             batch = missing_nodes[i:i+BATCH_SIZE]
 
-            create_query = f"""WITH $batch as batch 
-            UNWIND batch as item CREATE (n:{type}) 
-            SET n += item RETURN n.{prop_name} as {prop_name}, ID(n) as _id"""
+            create_query = f"""WITH $batch AS batch 
+            UNWIND batch AS item CREATE (n:{type}) 
+            SET n += item RETURN n.{prop_name} AS {prop_name}, ID(n) AS _id"""
 
             new_nodes = self.tx.run(create_query, batch=batch)
 
@@ -254,7 +254,7 @@ class IYP(object):
         """Find all nodes in the graph which have an EXTERNAL_ID relationship with
         the given id_type. Return None if the node does not exist."""
 
-        result = self.tx.run(f"MATCH (a)-[:EXTERNAL_ID]->(i:{id_type}) RETURN i.id as extid, ID(a) as nodeid")
+        result = self.tx.run(f"MATCH (a)-[:EXTERNAL_ID]->(i:{id_type}) RETURN i.id AS extid, ID(a) AS nodeid")
 
         ids = {}
         for node in result:
@@ -289,23 +289,23 @@ class IYP(object):
         for i in range(0, len(links), BATCH_SIZE):
             batch = links[i:i+BATCH_SIZE]
 
-            create_query = f"""WITH $batch as batch 
-            UNWIND batch as link 
+            create_query = f"""WITH $batch AS batch 
+            UNWIND batch AS link 
                 MATCH (x), (y)
                 WHERE ID(x) = link.src_id AND ID(y) = link.dst_id
                 CREATE (x)-[l:{type}]->(y) 
                 WITH l, link
-                UNWIND link.props as prop 
+                UNWIND link.props AS prop 
                     SET l += prop """
 
             if action == 'merge':
-                create_query = f"""WITH $batch as batch 
-                UNWIND batch as link 
+                create_query = f"""WITH $batch AS batch 
+                UNWIND batch AS link 
                     MATCH (x), (y)
                     WHERE ID(x) = link.src_id AND ID(y) = link.dst_id
                     MERGE (x)-[l:{type}]-(y) 
                     WITH l,  link
-                    UNWIND link.props as prop 
+                    UNWIND link.props AS prop 
                         SET l += prop """
 
 

--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -10,7 +10,7 @@ NODE_CONSTRAINTS = {
                 'asn': set(['UNIQUE', 'NOT NULL'])
                 } ,
 
-        'PREFIX': {
+        'Prefix': {
                 'prefix': set(['UNIQUE', 'NOT NULL']), 
                 #                'af': set(['NOT NULL'])
                 },
@@ -20,22 +20,22 @@ NODE_CONSTRAINTS = {
                 #'af': set(['NOT NULL'])
                 },
 
-        'DOMAIN_NAME': {
+        'DomainName': {
                 'name': set(['UNIQUE', 'NOT NULL'])
                 },
 
-        'COUNTRY': {
+        'Country': {
                 'country_code': set(['UNIQUE', 'NOT NULL'])
                 },
 
-        'ORGANIZATION': {
+        'Organization': {
                 'name': set(['NOT NULL'])
                 },
     }
 
 # Properties that may be frequently queried and that are not constraints
 NODE_INDEXES = {
-        'PEERINGDB_ORG_ID': [ 'id' ]
+        'PeeringDBOrgID': [ 'id' ]
         }
 
 # Set of node labels with constrains (ease search for node merging)

--- a/iyp/crawlers/apnic/README.md
+++ b/iyp/crawlers/apnic/README.md
@@ -14,7 +14,7 @@ Connect AS to country nodes with a 'population' relationship representing the
 percentage of the country's population hosted by the AS.
 
 ```
-(:AS {asn:2516})-[:POPULATION {percent:19.3}]-(:COUNTRY {country_code:'JP'})
+(:AS {asn:2516})-[:POPULATION {percent:19.3}]-(:Country {country_code:'JP'})
 ```
 
 
@@ -30,14 +30,14 @@ Connect ASes to ranking nodes which are also connected to a country. Meaning
 that an AS is ranked for a certain country in terms of population.
 For example:
 ```
-(:AS  {asn:2516})-[:RANK {rank:1}]-(:RANKING)--(:COUNTRY {country_code:'JP'})
+(:AS  {asn:2516})-[:RANK {rank:1}]-(:Ranking)--(:Country {country_code:'JP'})
 ```
 
 ### AS name
 Connect AS to names nodes, providing the name of ranked ASes. 
 For example:
 ```
-(:AS {asn:2497})-[:NAME]-(:NAME {name:'IIJ'})
+(:AS {asn:2497})-[:NAME]-(:Name {name:'IIJ'})
 ```
 
 

--- a/iyp/crawlers/apnic/eyeball.py
+++ b/iyp/crawlers/apnic/eyeball.py
@@ -25,8 +25,8 @@ class Crawler(BaseCrawler):
             logging.info(f'processing {country}')
 
             # Get the QID of the country and corresponding ranking
-            cc_qid = self.iyp.get_node('COUNTRY', {'country_code': cc}, create=True)
-            ranking_qid = self.iyp.get_node('RANKING', {'name': f'APNIC eyeball estimates ({cc})'}, create=True)
+            cc_qid = self.iyp.get_node('Country', {'country_code': cc}, create=True)
+            ranking_qid = self.iyp.get_node('Ranking', {'name': f'APNIC eyeball estimates ({cc})'}, create=True)
             statements = [ ['COUNTRY', cc_qid, self.reference] ]
             self.iyp.add_links(ranking_qid, statements)
 
@@ -51,7 +51,7 @@ class Crawler(BaseCrawler):
 
             # Get node IDs
             self.asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns, all=False)
-            self.name_id = self.iyp.batch_get_nodes('NAME', 'name', names, all=False)
+            self.name_id = self.iyp.batch_get_nodes('Name', 'name', names, all=False)
 
             # Compute links
             country_links = []
@@ -60,7 +60,7 @@ class Crawler(BaseCrawler):
             name_links = []
             for asn in ranking:
                 asn_qid = self.asn_id[asn['as']] #self.iyp.get_node('AS', {'asn': asn[2:]}, create=True)
-                name_qid = self.name_id[asn['autnum']] #self.iyp.get_node('NAME', {'name': name}, create=True)
+                name_qid = self.name_id[asn['autnum']] #self.iyp.get_node('Name', {'name': name}, create=True)
 
                 name_links.append( {'src_id': asn_qid, 'dst_id': name_qid, 'props':[self.reference]} )
                 country_links.append( {'src_id': asn_qid, 'dst_id': cc_qid, 'props':[self.reference]} )

--- a/iyp/crawlers/bgpkit/README.md
+++ b/iyp/crawlers/bgpkit/README.md
@@ -24,14 +24,14 @@ Connect AS nodes to BGP route collector nodes, meaning that an AS peers with
 a route collector hence participating in the RIS or RouteViews projects.
 
 ```
-(:AS {asn:2497})-[:PEERS_WITH]-(:BGP_COLLECTOR {project: 'riperis', name:'rrc06'})
+(:AS {asn:2497})-[:PEERS_WITH]-(:BGPCollector {project: 'riperis', name:'rrc06'})
 ```
 
 ### Prefix to ASN
 Connect AS nodes to prefix nodes representing the prefixes originated by an AS.
 For example:
 ```
-(:AS  {asn:2497})-[:ORIGINATE]-(:PREFIX {prefix: '101.128.128.0/17'})
+(:AS  {asn:2497})-[:ORIGINATE]-(:Prefix {prefix: '101.128.128.0/17'})
 ```
 
 ## Dependence

--- a/iyp/crawlers/bgpkit/peerstats.py
+++ b/iyp/crawlers/bgpkit/peerstats.py
@@ -54,7 +54,7 @@ class Crawler(BaseCrawler):
             # keep track of collector and reference url
             stats = json.load(bz2.open(req.raw))
             collector_qid = self.iyp.get_node(
-                    'BGP_COLLECTOR', 
+                    'BGPCollector',
                     {'name': stats['collector'], 'project': stats['project']},
                     create=True
                     )

--- a/iyp/crawlers/bgpkit/pfx2asn.py
+++ b/iyp/crawlers/bgpkit/pfx2asn.py
@@ -32,7 +32,7 @@ class Crawler(BaseCrawler):
         logging.info('Pushing nodes to neo4j...\n')
         # get ASNs and prefixes IDs
         self.asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns)
-        self.prefix_id = self.iyp.batch_get_nodes('PREFIX', 'prefix', prefixes)
+        self.prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix', prefixes)
 
         # Compute links
         links = []

--- a/iyp/crawlers/bgptools/README.md
+++ b/iyp/crawlers/bgptools/README.md
@@ -11,14 +11,14 @@ Data collected by BGP.Tools, including:
 Connect AS to names nodes, providing the name of an AS.
 For example:
 ```
-(:AS {asn:2497})-[:NAME]-(:NAME {name:'IIJ'})
+(:AS {asn:2497})-[:NAME]-(:Name {name:'IIJ'})
 ```
 
 ### AS tags
 Connect AS to tag nodes meaning that an AS has been categorized according to the
 given tag.
 ```
-(:AS {asn:2497})-[:CATEGORIZED]-(:TAG {label: 'Internet Critical Infra'})
+(:AS {asn:2497})-[:CATEGORIZED]-(:Tag {label: 'Internet Critical Infra'})
 ```
 
 

--- a/iyp/crawlers/bgptools/as_names.py
+++ b/iyp/crawlers/bgptools/as_names.py
@@ -42,7 +42,7 @@ class Crawler(BaseCrawler):
 
         # get ASNs and names IDs
         self.asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns)
-        self.name_id = self.iyp.batch_get_nodes('NAME', 'name', names)
+        self.name_id = self.iyp.batch_get_nodes('Name', 'name', names)
 
         # Compute links
         links = []

--- a/iyp/crawlers/bgptools/tags.py
+++ b/iyp/crawlers/bgptools/tags.py
@@ -56,7 +56,7 @@ class Crawler(BaseCrawler):
                 print(req.text)
                 sys.exit('Error while fetching AS names')
 
-            self.tag_qid = self.iyp.get_node('TAG', {'label': label}, create=True)
+            self.tag_qid = self.iyp.get_node('Tag', {'label': label}, create=True)
             for line in req.text.splitlines():
                 # skip header
                 if line.startswith('asn'):

--- a/iyp/crawlers/caida/README.md
+++ b/iyp/crawlers/caida/README.md
@@ -10,21 +10,21 @@ Connect ASes nodes to a single ranking node corresponding to ASRank. The rank is
 given as a link attribute.
 For example:
 ```
-(:AS  {asn:2497})-[:RANK {rank:87}]-(:RANKING {name:'CAIDA ASRank'})
+(:AS  {asn:2497})-[:RANK {rank:87}]-(:Ranking {name:'CAIDA ASRank'})
 ```
 
 ### Country
 Connect AS to country nodes, meaning that the AS is registered in that country.
 
 ```
-(:AS)-[:COUNTRY]-(:COUNTRY)
+(:AS)-[:COUNTRY]-(:Country)
 ```
 
 ### AS name
 Connect AS to names nodes, providing the name of an AS.
 For example:
 ```
-(:AS {asn:2497})-[:NAME]-(:NAME {name:'IIJ'})
+(:AS {asn:2497})-[:NAME]-(:Name {name:'IIJ'})
 ```
 
 ## Dependence

--- a/iyp/crawlers/caida/asrank.py
+++ b/iyp/crawlers/caida/asrank.py
@@ -17,8 +17,8 @@ class Crawler(BaseCrawler):
 
         # get ASNs, names, and countries IDs
         self.asn_id = self.iyp.batch_get_nodes('AS', 'asn')
-        self.country_id = self.iyp.batch_get_nodes('COUNTRY', 'country_code')
-        self.asrank_qid = self.iyp.get_node('RANKING', {'name': f'CAIDA ASRank'}, create=True)
+        self.country_id = self.iyp.batch_get_nodes('Country', 'country_code')
+        self.asrank_qid = self.iyp.get_node('Ranking', {'name': f'CAIDA ASRank'}, create=True)
 
         has_next = True
         i = 0
@@ -61,7 +61,7 @@ class Crawler(BaseCrawler):
                 if int(asn['asn']) not in self.asn_id:
                     self.asn_id[int(asn['asn'])] = self.iyp.get_node('AS', {'asn':int(asn['asn'])}, create=True)
                 if asn['country']['iso'] not in self.country_id:
-                    self.country_id[asn['country']['iso']] = self.iyp.get_node('COUNTRY', {'country_code':asn['country']['iso']}, create=True)
+                    self.country_id[asn['country']['iso']] = self.iyp.get_node('Country', {'country_code':asn['country']['iso']}, create=True)
 
                 asn_qid = self.asn_id[int(asn['asn'])]
                 country_qid = self.country_id[asn['country']['iso']]
@@ -75,7 +75,7 @@ class Crawler(BaseCrawler):
                 rank_links.append( { 'src_id':asn_qid, 'dst_id':self.asrank_qid, 'props':[self.reference, flat_asn] } ) # Set AS name
 
             # Push nodes
-            self.names_id = self.iyp.batch_get_nodes('NAME', 'name', names, all=False)
+            self.names_id = self.iyp.batch_get_nodes('Name', 'name', names, all=False)
 
             # Add dst_id in name_links
             for link in name_links :

--- a/iyp/crawlers/cloudflare/README.md
+++ b/iyp/crawlers/cloudflare/README.md
@@ -10,7 +10,7 @@ Connect domain name nodes to a single ranking node corresponding to Cloudflare
 top 100 ranking. The rank is given as a link attribute.
 For example:
 ```
-(:DOMAIN_NAME  {name:'google.com'})-[:RANK {rank:1}]-(:RANKING {name:'Cloudflare top 100 domains'})
+(:DomainName  {name:'google.com'})-[:RANK {rank:1}]-(:Ranking {name:'Cloudflare top 100 domains'})
 ```
 
 ## Dependence

--- a/iyp/crawlers/cloudflare/ranking_bucket.py
+++ b/iyp/crawlers/cloudflare/ranking_bucket.py
@@ -38,7 +38,7 @@ class Crawler(BaseCrawler):
 
         for dataset in req.json()['result']['datasets']:
             self.ranking_qid = self.iyp.get_node(
-                    'RANKING', 
+                    'Ranking',
                     {
                         'name': f'Cloudflare '+dataset['title'],
                         'description': dataset['description'],
@@ -85,7 +85,7 @@ class Crawler(BaseCrawler):
 
         # Commit to IYP
         # Get the AS's node ID (create if it is not yet registered) and commit changes
-        domain_qid = self.iyp.get_node('DOMAIN_NAME', {'name': domain}, create=True) 
+        domain_qid = self.iyp.get_node('DomainName', {'name': domain}, create=True)
         self.iyp.add_links( domain_qid, statements )
         
 # Main program

--- a/iyp/crawlers/cloudflare/top100.py
+++ b/iyp/crawlers/cloudflare/top100.py
@@ -22,7 +22,7 @@ class Crawler(BaseCrawler):
         """Fetch data and push to IYP. """
 
         self.cf_qid = self.iyp.get_node(
-                'RANKING', {'name': f'Cloudflare top 100 domains'}, create=True)
+                'Ranking', {'name': f'Cloudflare top 100 domains'}, create=True)
 
         # Fetch data
         headers = {
@@ -49,7 +49,7 @@ class Crawler(BaseCrawler):
 
         # Commit to IYP
         # Get the AS's node ID (create if it is not yet registered) and commit changes
-        domain_qid = self.iyp.get_node('DOMAIN_NAME', {'name': entry['domain']}, create=True) 
+        domain_qid = self.iyp.get_node('DomainName', {'name': entry['domain']}, create=True)
         self.iyp.add_links( domain_qid, statements )
         
 # Main program

--- a/iyp/crawlers/ihr/README.md
+++ b/iyp/crawlers/ihr/README.md
@@ -24,7 +24,7 @@ A Country AS dependency is computed in two different ways, emphasizing
 either the distribution of the country's population (a.k.a. Total eyeball) or 
 the country ASes (a.k.a. Total AS), for example:
 ```
-(:AS  {asn:2497})-[:RANK {rank:1, hege:0.19}]-(:RANKING {name:'IHR country ranking: Total AS (JP)'})--(:COUNTRY {country_code:'JP'})
+(:AS  {asn:2497})-[:RANK {rank:1, hege:0.19}]-(:Ranking {name:'IHR country ranking: Total AS (JP)'})--(:Country {country_code:'JP'})
 ```
 
 means that Japan ASes depends strongly (AS Hegemony equals 0.19) on AS2497.
@@ -34,10 +34,10 @@ Connect prefixes to their origin AS, their AS dependencies, their RPKI/IRR
 status, and their country (provided by Maxmind).
 
 ```
-(:PREFIX {prefix:'8.8.8.0/24'})-[:ORIGINATE]-(:AS {asn:15169})
-(:PREFIX {prefix:'8.8.8.0/24'})-[:DEPENDS_ON]-(:AS {asn:15169})
-(:PREFIX {prefix:'8.8.8.0/24'})-[:CATEGORIZED]-(:TAG {label: 'RPKI Valid'})
-(:PREFIX {prefix:'8.8.8.0/24'})-[:COUNTRY]-(:COUNTRY {country_code:'US'})
+(:Prefix {prefix:'8.8.8.0/24'})-[:ORIGINATE]-(:AS {asn:15169})
+(:Prefix {prefix:'8.8.8.0/24'})-[:DEPENDS_ON]-(:AS {asn:15169})
+(:Prefix {prefix:'8.8.8.0/24'})-[:CATEGORIZED]-(:Tag {label: 'RPKI Valid'})
+(:Prefix {prefix:'8.8.8.0/24'})-[:COUNTRY]-(:Country {country_code:'US'})
 ```
 
 ## Dependence

--- a/iyp/crawlers/ihr/country_dependency.py
+++ b/iyp/crawlers/ihr/country_dependency.py
@@ -54,7 +54,7 @@ class Crawler(BaseCrawler):
             }
 
             # Setup rankings' node
-            country_qid = self.iyp.get_node('COUNTRY', 
+            country_qid = self.iyp.get_node('Country',
                                             {
                                                 'country_code': cc, 
                                             },
@@ -75,7 +75,7 @@ class Crawler(BaseCrawler):
             links = []
             for metric, weight in [('Total eyeball', 'eyeball'), ('Total AS', 'as')]:
 
-                self.countryrank_qid = self.iyp.get_node( 'RANKING',
+                self.countryrank_qid = self.iyp.get_node( 'Ranking',
                         {'name': f'IHR country ranking: {metric} ({cc})'},
                         create=True
                         )

--- a/iyp/crawlers/ihr/rov.py
+++ b/iyp/crawlers/ihr/rov.py
@@ -70,9 +70,9 @@ class Crawler(BaseCrawler):
 
         logging.warning('Getting node IDs from neo4j...\n')
         asn_id = self.iyp.batch_get_nodes('AS', 'asn')
-        prefix_id = self.iyp.batch_get_nodes('PREFIX', 'prefix')
-        tag_id = self.iyp.batch_get_nodes('TAG', 'label')
-        country_id = self.iyp.batch_get_nodes('COUNTRY', 'country_code')
+        prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix')
+        tag_id = self.iyp.batch_get_nodes('Tag', 'label')
+        country_id = self.iyp.batch_get_nodes('Country', 'country_code')
 
         orig_links = []
         tag_links = []
@@ -92,7 +92,7 @@ class Crawler(BaseCrawler):
 
             prefix = rec['prefix']
             if prefix not in prefix_id:
-                prefix_id[prefix] = self.iyp.get_node('PREFIX', {'prefix': prefix}, create=True)
+                prefix_id[prefix] = self.iyp.get_node('Prefix', {'prefix': prefix}, create=True)
 
             # make status/country/origin links only for lines where asn=originasn
             if rec['asn_id'] == rec['originasn_id']:
@@ -103,15 +103,15 @@ class Crawler(BaseCrawler):
 
                 rpki_status = 'RPKI '+rec['rpki_status']
                 if rpki_status not in tag_id:
-                    tag_id[rpki_status] = self.iyp.get_node('TAG', {'label': rpki_status}, create=True)
+                    tag_id[rpki_status] = self.iyp.get_node('Tag', {'label': rpki_status}, create=True)
 
                 irr_status = 'IRR '+rec['irr_status']
                 if irr_status not in tag_id:
-                    tag_id[irr_status] = self.iyp.get_node('TAG', {'label': irr_status}, create=True)
+                    tag_id[irr_status] = self.iyp.get_node('Tag', {'label': irr_status}, create=True)
 
                 cc = rec['country_id']
                 if cc not in country_id:
-                    country_id[cc] = self.iyp.get_node('COUNTRY', {'country_code': cc}, create=True)
+                    country_id[cc] = self.iyp.get_node('Country', {'country_code': cc}, create=True)
 
                 # Compute links
                 orig_links.append( {

--- a/iyp/crawlers/manrs/members.py
+++ b/iyp/crawlers/manrs/members.py
@@ -45,7 +45,7 @@ class Crawler(BaseCrawler):
         # Get the ID for the four items representing MANRS actions
         for action in self.actions:
             action['qid'] = self.iyp.get_node(
-                                            'MANRSAction',
+                                            'ManrsAction',
                                             {
                                                 'name': action['label'],
                                                 'description': action['description']

--- a/iyp/crawlers/manrs/members.py
+++ b/iyp/crawlers/manrs/members.py
@@ -17,7 +17,7 @@ class Crawler(BaseCrawler):
         super().__init__(organization, url, name)
 
         self.manrs_qid = self.iyp.get_node(
-                                        'ORGANIZATION', 
+                                        'Organization',
                                         { 'name': 'MANRS' },
                                         create=True
                                         )
@@ -45,7 +45,7 @@ class Crawler(BaseCrawler):
         # Get the ID for the four items representing MANRS actions
         for action in self.actions:
             action['qid'] = self.iyp.get_node(
-                                            'MANRS_ACTION', 
+                                            'MANRSAction',
                                             {
                                                 'name': action['label'],
                                                 'description': action['description']
@@ -92,7 +92,7 @@ class Crawler(BaseCrawler):
 
         # set countries
         for cc in areas.split(';'):
-            country_qid = self.iyp.get_node('COUNTRY', {'country_code': cc}, create=True)
+            country_qid = self.iyp.get_node('Country', {'country_code': cc}, create=True)
             statements.append([ 'COUNTRY', country_qid, self.reference])
 
         # set actions

--- a/iyp/crawlers/nro/delegated_stats.py
+++ b/iyp/crawlers/nro/delegated_stats.py
@@ -60,9 +60,9 @@ class Crawler(BaseCrawler):
 
         # Create all nodes
         logging.warning('Pushing nodes to neo4j...\n')
-        opaqueid_id = self.iyp.batch_get_nodes('OPAQUE_ID', 'id', opaqueids)
-        prefix_id = self.iyp.batch_get_nodes('PREFIX', 'prefix', prefixes)
-        country_id = self.iyp.batch_get_nodes('COUNTRY', 'country_code', countries)
+        opaqueid_id = self.iyp.batch_get_nodes('OpaqueID', 'id', opaqueids)
+        prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix', prefixes)
+        country_id = self.iyp.batch_get_nodes('Country', 'country_code', countries)
 
         # Compute links
         country_links = []

--- a/iyp/crawlers/openintel/tranco1m.py
+++ b/iyp/crawlers/openintel/tranco1m.py
@@ -133,7 +133,7 @@ class Crawler(BaseCrawler):
         #sld_a_mappings.to_csv(args.out_file, sep=",", header=True, index=False)
         #print("Written results to '{}' [{:.2f}MiB].".format(args.out_file, os.path.getsize(args.out_file) / (1024 * 1024)))
 
-        domain_id = self.iyp.batch_get_nodes('DOMAIN_NAME', 'name', set(df['query_name']))
+        domain_id = self.iyp.batch_get_nodes('DomainName', 'name', set(df['query_name']))
         ip_id = self.iyp.batch_get_nodes('IP', 'ip', set(df['ip4_address']))
 
         links = []

--- a/iyp/crawlers/peeringdb/fac.py
+++ b/iyp/crawlers/peeringdb/fac.py
@@ -16,8 +16,8 @@ URL = 'https://peeringdb.com/api/fac'
 NAME = 'peeringdb.fac'
 
 # Label used for the nodes representing the organization and facility IDs
-ORGID_LABEL = 'PeeringDBOrgID'
-FACID_LABEL = 'PeeringDBFacID'
+ORGID_LABEL = 'PeeringdbOrgID'
+FACID_LABEL = 'PeeringdbFacID'
 
 API_KEY = ""
 if os.path.exists('config.json'): 

--- a/iyp/crawlers/peeringdb/fac.py
+++ b/iyp/crawlers/peeringdb/fac.py
@@ -16,8 +16,8 @@ URL = 'https://peeringdb.com/api/fac'
 NAME = 'peeringdb.fac'
 
 # Label used for the nodes representing the organization and facility IDs
-ORGID_LABEL = 'PEERINGDB_ORG_ID' 
-FACID_LABEL = 'PEERINGDB_FAC_ID' 
+ORGID_LABEL = 'PeeringDBOrgID'
+FACID_LABEL = 'PeeringDBFacID'
 
 API_KEY = ""
 if os.path.exists('config.json'): 
@@ -63,10 +63,10 @@ class Crawler(BaseCrawler):
                 countries.add( fac['country'] )
 
         # push nodes
-        self.fac_id = self.iyp.batch_get_nodes('FACILITY', 'name', facs)
-        self.name_id = self.iyp.batch_get_nodes('NAME', 'name', names)
+        self.fac_id = self.iyp.batch_get_nodes('Facility', 'name', facs)
+        self.name_id = self.iyp.batch_get_nodes('Name', 'name', names)
         self.website_id = self.iyp.batch_get_nodes('URL', 'url', websites)
-        self.country_id = self.iyp.batch_get_nodes('COUNTRY', 'country_code', countries)
+        self.country_id = self.iyp.batch_get_nodes('Country', 'country_code', countries)
         self.facid_id = self.iyp.batch_get_nodes(FACID_LABEL, 'id', facids)
 
         # get organization nodes

--- a/iyp/crawlers/peeringdb/ix.py
+++ b/iyp/crawlers/peeringdb/ix.py
@@ -22,13 +22,13 @@ URL_PDB_LANS = 'https://peeringdb.com/api/ixlan?depth=2'
 URL_PDB_NETFAC = 'https://peeringdb.com/api/netfac'
 
 # Label used for nodes representing the exchange point IDs
-IXID_LABEL = 'PEERINGDB_IX_ID' 
+IXID_LABEL = 'PeeringDBIXID'
 # Label used for nodes representing the organization IDs
-ORGID_LABEL = 'PEERINGDB_ORG_ID' 
+ORGID_LABEL = 'PeeringDBOrgID'
 # Label used for the nodes representing the network IDs
-NETID_LABEL = 'PEERINGDB_NET_ID' 
+NETID_LABEL = 'PeeringDBNetID'
 # Label used for the nodes representing the facility IDs
-FACID_LABEL = 'PEERINGDB_FAC_ID' 
+FACID_LABEL = 'PeeringDBFacID'
 
 API_KEY = ""
 if os.path.exists('config.json'): 
@@ -77,7 +77,7 @@ class Crawler(BaseCrawler):
         # get organization, country nodes
         self.org_id = self.iyp.batch_get_node_extid(ORGID_LABEL)
         self.fac_id = self.iyp.batch_get_node_extid(FACID_LABEL)
-        self.country_id = self.iyp.batch_get_nodes('COUNTRY', 'country_code')
+        self.country_id = self.iyp.batch_get_nodes('Country', 'country_code')
 
         req = self.requests.get( URL_PDB_IXS, headers=self.headers)
         if req.status_code != 200:
@@ -177,8 +177,8 @@ class Crawler(BaseCrawler):
 
 
         # TODO add the type PEERING_LAN? may break the unique constraint
-        self.prefix_id = self.iyp.batch_get_nodes('PREFIX', 'prefix', prefixes)
-        self.name_id = self.iyp.batch_get_nodes('NAME', 'name', net_names)
+        self.prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix', prefixes)
+        self.name_id = self.iyp.batch_get_nodes('Name', 'name', net_names)
         self.website_id = self.iyp.batch_get_nodes('URL', 'url', net_website)
         self.netid_id = self.iyp.batch_get_nodes(NETID_LABEL, 'id', net_extid)
         self.asn_id = self.iyp.batch_get_nodes('AS', 'asn', net_asn)
@@ -251,7 +251,7 @@ class Crawler(BaseCrawler):
         self.ixext_id = self.iyp.batch_get_nodes(IXID_LABEL, 'id', all_ixs_id)
         self.ix_id = self.iyp.batch_get_nodes('IXP', 'name', all_ixs_name)
         self.website_id = self.iyp.batch_get_nodes('URL', 'url', all_ixs_website)
-        self.name_id = self.iyp.batch_get_nodes('NAME', 'name', all_ixs_name)
+        self.name_id = self.iyp.batch_get_nodes('Name', 'name', all_ixs_name)
 
         # Compute links
         name_links = []

--- a/iyp/crawlers/peeringdb/ix.py
+++ b/iyp/crawlers/peeringdb/ix.py
@@ -22,13 +22,13 @@ URL_PDB_LANS = 'https://peeringdb.com/api/ixlan?depth=2'
 URL_PDB_NETFAC = 'https://peeringdb.com/api/netfac'
 
 # Label used for nodes representing the exchange point IDs
-IXID_LABEL = 'PeeringDBIXID'
+IXID_LABEL = 'PeeringdbIXID'
 # Label used for nodes representing the organization IDs
-ORGID_LABEL = 'PeeringDBOrgID'
+ORGID_LABEL = 'PeeringdbOrgID'
 # Label used for the nodes representing the network IDs
-NETID_LABEL = 'PeeringDBNetID'
+NETID_LABEL = 'PeeringdbNetID'
 # Label used for the nodes representing the facility IDs
-FACID_LABEL = 'PeeringDBFacID'
+FACID_LABEL = 'PeeringdbFacID'
 
 API_KEY = ""
 if os.path.exists('config.json'): 

--- a/iyp/crawlers/peeringdb/org.py
+++ b/iyp/crawlers/peeringdb/org.py
@@ -14,7 +14,7 @@ URL = 'https://peeringdb.com/api/org'
 NAME = 'peeringdb.org'
 
 # Label used for the class/item representing the organization IDs
-ORGID_LABEL = 'PeeringDBOrgID'
+ORGID_LABEL = 'PeeringdbOrgID'
 
 API_KEY = ""
 if os.path.exists('config.json'): 

--- a/iyp/crawlers/peeringdb/org.py
+++ b/iyp/crawlers/peeringdb/org.py
@@ -14,7 +14,7 @@ URL = 'https://peeringdb.com/api/org'
 NAME = 'peeringdb.org'
 
 # Label used for the class/item representing the organization IDs
-ORGID_LABEL = 'PEERINGDB_ORG_ID' 
+ORGID_LABEL = 'PeeringDBOrgID'
 
 API_KEY = ""
 if os.path.exists('config.json'): 
@@ -58,10 +58,10 @@ class Crawler(BaseCrawler):
                 countries.add( org['country'] )
 
         # push nodes
-        self.org_id = self.iyp.batch_get_nodes('ORGANIZATION', 'name', orgs)
-        self.name_id = self.iyp.batch_get_nodes('NAME', 'name', names)
+        self.org_id = self.iyp.batch_get_nodes('Organization', 'name', orgs)
+        self.name_id = self.iyp.batch_get_nodes('Name', 'name', names)
         self.website_id = self.iyp.batch_get_nodes('URL', 'url', websites)
-        self.country_id = self.iyp.batch_get_nodes('COUNTRY', 'country_code', countries)
+        self.country_id = self.iyp.batch_get_nodes('Country', 'country_code', countries)
         self.orgid_id = self.iyp.batch_get_nodes(ORGID_LABEL, 'id', orgids)
 
         # compute links

--- a/iyp/crawlers/ripe/as_names.py
+++ b/iyp/crawlers/ripe/as_names.py
@@ -35,8 +35,8 @@ class Crawler(BaseCrawler):
 
         # get node IDs for ASNs, names, and countries 
         asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns)
-        name_id = self.iyp.batch_get_nodes('NAME', 'name', names)
-        country_id = self.iyp.batch_get_nodes('COUNTRY', 'country_code', countries)
+        name_id = self.iyp.batch_get_nodes('Name', 'name', names)
+        country_id = self.iyp.batch_get_nodes('Country', 'country_code', countries)
 
         # Compute links
         name_links = []

--- a/iyp/crawlers/ripe/roa.py
+++ b/iyp/crawlers/ripe/roa.py
@@ -63,7 +63,7 @@ class Crawler(BaseCrawler):
 
             # get ASNs and prefixes IDs
             asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns)
-            prefix_id = self.iyp.batch_get_nodes('PREFIX', 'prefix', set(prefix_info.keys()))
+            prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix', set(prefix_info.keys()))
 
             links = []
             for prefix, attributes in prefix_info.items():

--- a/iyp/crawlers/stanford/README.md
+++ b/iyp/crawlers/stanford/README.md
@@ -10,7 +10,7 @@ intelligence databases, website classifiers, and a machine learning algorithm.
 Connect AS to tag nodes meaning that an AS has been categorized according to the
 given tag.
 ```
-(:AS {asn:32})-[:CATEGORIZED]-(:TAG {label: 'Colleges, Universities, and Professional Schools'})
+(:AS {asn:32})-[:CATEGORIZED]-(:Tag {label: 'Colleges, Universities, and Professional Schools'})
 ```
 
 ## Dependence

--- a/iyp/crawlers/stanford/asdb.py
+++ b/iyp/crawlers/stanford/asdb.py
@@ -40,7 +40,7 @@ class Crawler(BaseCrawler):
 
         # get ASNs and names IDs
         asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns)
-        category_id = self.iyp.batch_get_nodes('TAG', 'label', categories)
+        category_id = self.iyp.batch_get_nodes('Tag', 'label', categories)
 
         # Compute links
         links = []

--- a/iyp/crawlers/tranco/top1M.py
+++ b/iyp/crawlers/tranco/top1M.py
@@ -15,7 +15,7 @@ class Crawler(BaseCrawler):
     def run(self):
         """Fetch Tranco top 1M and push to IYP. """
 
-        self.tranco_qid = self.iyp.get_node('RANKING', {'name': f'Tranco top 1M'}, create=True)
+        self.tranco_qid = self.iyp.get_node('Ranking', {'name': f'Tranco top 1M'}, create=True)
 
         sys.stderr.write('Downloading latest list...\n')
         req = requests.get(URL)
@@ -34,7 +34,7 @@ class Crawler(BaseCrawler):
                     domains.add( domain )
                     links.append( { 'src_name':domain, 'dst_id':self.tranco_qid, 'props':[self.reference, {'rank': int(rank)}] } )
 
-        name_id = self.iyp.batch_get_nodes('DOMAIN_NAME', 'name', domains)
+        name_id = self.iyp.batch_get_nodes('DomainName', 'name', domains)
 
         for link in links:
             link['src_id'] = name_id[link['src_name']]

--- a/iyp/post/address_family.py
+++ b/iyp/post/address_family.py
@@ -5,11 +5,11 @@ import radix
 
 class PostProcess(BasePostProcess):
     def run(self):
-        """Add address family (4 or 6 for IPv4 or IPv6) to all IP and PREFIX nodes."""
+        """Add address family (4 or 6 for IPv4 or IPv6) to all IP and Prefix nodes."""
 
         # Update prefixes
-        self.iyp.tx.run("match (pfx:PREFIX) where pfx.prefix contains '.' SET pfx.af = 4;")
-        self.iyp.tx.run("match (pfx:PREFIX) where pfx.prefix contains ':' SET pfx.af = 6;")
+        self.iyp.tx.run("match (pfx:Prefix) where pfx.prefix contains '.' SET pfx.af = 4;")
+        self.iyp.tx.run("match (pfx:Prefix) where pfx.prefix contains ':' SET pfx.af = 6;")
 
         # Update IP addresses
         self.iyp.tx.run("match (ip:IP) where ip.ip contains '.' SET ip.af = 4;")

--- a/iyp/post/address_family.py
+++ b/iyp/post/address_family.py
@@ -8,12 +8,12 @@ class PostProcess(BasePostProcess):
         """Add address family (4 or 6 for IPv4 or IPv6) to all IP and Prefix nodes."""
 
         # Update prefixes
-        self.iyp.tx.run("match (pfx:Prefix) where pfx.prefix contains '.' SET pfx.af = 4;")
-        self.iyp.tx.run("match (pfx:Prefix) where pfx.prefix contains ':' SET pfx.af = 6;")
+        self.iyp.tx.run("MATCH (pfx:Prefix) WHERE pfx.prefix CONTAINS '.' SET pfx.af = 4;")
+        self.iyp.tx.run("MATCH (pfx:Prefix) WHERE pfx.prefix CONTAINS ':' SET pfx.af = 6;")
 
         # Update IP addresses
-        self.iyp.tx.run("match (ip:IP) where ip.ip contains '.' SET ip.af = 4;")
-        self.iyp.tx.run("match (ip:IP) where ip.ip contains ':' SET ip.af = 6;")
+        self.iyp.tx.run("MATCH (ip:IP) WHERE ip.ip CONTAINS '.' SET ip.af = 4;")
+        self.iyp.tx.run("MATCH (ip:IP) WHERE ip.ip CONTAINS ':' SET ip.af = 6;")
 
 
 if __name__ == '__main__':

--- a/iyp/post/ip2prefix.py
+++ b/iyp/post/ip2prefix.py
@@ -5,10 +5,10 @@ import radix
 
 class PostProcess(BasePostProcess):
     def run(self):
-        """Fetch all IP and PREFIX nodes, then link IPs to their most specific prefix."""
+        """Fetch all IP and Prefix nodes, then link IPs to their most specific prefix."""
 
         # Get all prefixes in a radix trie
-        prefix_id = self.iyp.batch_get_nodes('PREFIX', 'prefix')
+        prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix')
 
         rtree = radix.Radix()
         for prefix, prefix_qid in prefix_id.items():


### PR DESCRIPTION
Fix issue #20.

Before merging this we need to decide one additional thing: I kept the capitalization of acronyms (`IP`, `AS`, etc.) as is. Strict CamelCase would  make them `Ip`, `As`, etc., which looks weird I think. *But*, there are other examples that now look hideous as well, e.g., `MANRSAction` or `PeeringDBIXID`. I would propose to either go strict CamelCase or rename the cases that now look weird.

During the refactor I also noticed three possible future ToDo's:
1. Make relationship names consistent with the graph database principle of "forming sentences". At the moment there is a relationship `NAME` and a node `Name`. The relationships should be something like `IS_NAMED` / `HAS_NAME`.
2. We should probably gather all node and relationship types in one file as variables and use them, this will make it easier to get an overview of the existing types and also prevents spelling mistakes.
3. It would be cool to create some dummy replies for the crawlers so that we can test the [create_db](../blob/main/create_db.py) file without actually having to create the entire database.