### PR TITLE
fix: changed depends_on to type array

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,5 +21,4 @@ services:
     environment:
       - NEO4J_AUTH=neo4j/password
     depends_on:
-      iyp_loader:
-        condition: service_completed_successfully
+      - iyp_loader


### PR DESCRIPTION
The depends_on field was changed according to the version 3 compose file structure.

 https://docs.docker.com/compose/compose-file/compose-file-v3/#:~:text=Compose%201.27.0%2B.-,Compose%20file%20structure%20and%20examples,-%F0%9F%94%97

#29 