### PR TITLE
Fix missing property formatting for batch methods

### DIFF
--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -80,11 +80,12 @@ def batch_format_link_properties(links: list, inplace=True) -> list:
     links: List of relationships as defined in batch_add_links"""
     if inplace:
         for l in links:
-            l['props'] = format_properties(l['props'])
+            for idx, prop_dict in enumerate(l['props']):
+                l['props'][idx] = format_properties(prop_dict)
         return links
     return [{'src_id': l['src_id'],
              'dst_id': l['dst_id'],
-             'props': format_properties(l['props'])}
+             'props': [format_properties(d) for d in l['props']]}
             for l in links]
 
 

--- a/iyp/crawlers/cloudflare/dns_top_ases.py
+++ b/iyp/crawlers/cloudflare/dns_top_ases.py
@@ -34,7 +34,7 @@ class Crawler(Crawler):
             self.statements.append({
                      'src_id': self.domain_names_id[domain], 
                      'dst_id': self.as_id[asn], 
-                     'props': dict(flat_prop, **self.reference) 
+                     'props': [flat_prop, self.reference]
                      })
         
         

--- a/iyp/crawlers/cloudflare/dns_top_locations.py
+++ b/iyp/crawlers/cloudflare/dns_top_locations.py
@@ -138,7 +138,7 @@ class Crawler(BaseCrawler):
             self.statements.append( { 
                      'src_id': self.domain_names_id[domain], 
                      'dst_id': self.country_id[cc], 
-                     'props': dict(flat_prop, **self.reference) 
+                     'props': [flat_prop, self.reference]
                      })
 
         

--- a/iyp/crawlers/cloudflare/ranking_bucket.py
+++ b/iyp/crawlers/cloudflare/ranking_bucket.py
@@ -13,6 +13,7 @@ from iyp import BaseCrawler
 # Organization name and URL to data
 ORG = 'Cloudflare'
 URL_DATASETS = 'https://api.cloudflare.com/client/v4/radar/datasets?limit=10&offset=0&datasetType=RANKING_BUCKET&format=json'
+URL = ''
 URL_DL = 'https://api.cloudflare.com/client/v4/radar/datasets/download'
 NAME = 'cloudflare.ranking_bucket'
 
@@ -98,7 +99,7 @@ class Crawler(BaseCrawler):
                                            create=True)
 
             # Create RANK relationships
-            domain_links = [{'src_id': domain_ids[domain], 'dst_id': ranking_id, 'props': self.reference}
+            domain_links = [{'src_id': domain_ids[domain], 'dst_id': ranking_id, 'props': [self.reference]}
                             for domain in domains]
             if domain_links:
                 # Push RANK relationships to IYP
@@ -122,7 +123,7 @@ if __name__ == '__main__':
     )
     logging.info(f'Started: {sys.argv}')
 
-    crawler = Crawler(ORG, '', NAME)
+    crawler = Crawler(ORG, URL, NAME)
     if args.unit_test:
         crawler.unit_test(logging)
     else:

--- a/iyp/crawlers/openintel/tranco1m.py
+++ b/iyp/crawlers/openintel/tranco1m.py
@@ -131,7 +131,9 @@ class Crawler(BaseCrawler):
             # IPv4 record
             (pandas_df.response_type == "A") &
             # Filter out non-apex records
-            (~pandas_df.query_name.str.startswith("www."))
+            (~pandas_df.query_name.str.startswith("www.")) &
+            # Filter missing IPv4 addresses (there is at least one...)
+            (pandas_df.ip4_address.notnull())
         ][["query_name", "ip4_address"]].drop_duplicates()
         df.query_name = df.query_name.str[:-1] # Remove root '.'
 

--- a/iyp/crawlers/ripe/as_names.py
+++ b/iyp/crawlers/ripe/as_names.py
@@ -25,6 +25,12 @@ class Crawler(BaseCrawler):
         for line in req.text.splitlines():
             asn, _, name_cc = line.partition(' ')
             name, _, cc = name_cc.rpartition(', ')
+
+            # Country codes are two digits
+            if len(cc) > 2:
+                print(cc)
+                continue
+
             asn = int(asn)
             lines.append([ asn, name, cc ])
 

--- a/send_email.py
+++ b/send_email.py
@@ -10,7 +10,7 @@ with open('config.json', 'r') as fp:
 
 
 def send_email(e):
-    email_config = conf['email']
+    email_config = conf.get('email')
     if email_config is not None and email_config['email_address'] != "" and email_config['smtp_server'] != "" and email_config['smtp_port'] != "" and email_config['username'] != "" and email_config['password'] != "":
         # Send an email
         sender = email_config['email_address']


### PR DESCRIPTION
The property formatting was not applied when creating nodes and relationships in batches, so I fixed that.
This required altering the structure of the existing functions slightly.