### PR TITLE
Fix PCH crawler

### DIFF
--- a/iyp/crawlers/pch/__init__.py
+++ b/iyp/crawlers/pch/__init__.py
@@ -266,10 +266,9 @@ class RoutingSnapshotCrawler(BaseCrawler):
                                  f'{latest_available_date.strftime("%Y-%m-%d")}')
             if failed_fetches:
                 # Max lookback reached.
-                logging.error(f'Failed to find current data for {len(failed_fetches)} collectors: {failed_fetches}')
+                logging.warning(f'Failed to find current data for {len(failed_fetches)} collectors: {failed_fetches}')
                 print(f'Failed to find current data for {len(failed_fetches)} collectors: {failed_fetches}',
                       file=sys.stderr)
-                return True
 
         return False
 


### PR DESCRIPTION
Fix #67 and also make crawler less chatty (many collectors include their default route, which we do not use).

If we can not find recent data for a collector, it should only result in a warning, not stop the crawler.