### PR TITLE
Make `batch_create_nodes` method idempotent

### DIFF
--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -313,8 +313,8 @@ class IYP(object):
             batch = node_props[i:i + BATCH_SIZE]
 
             create_query = f"""WITH $batch AS batch
-            UNWIND batch AS item CREATE (n:{type_str})
-            SET n = item RETURN n.{id_prop} AS {id_prop}, ID(n) AS _id"""
+            UNWIND batch AS item MERGE (n:{type_str} {{{id_prop}: item.{id_prop}}})
+            SET n += item RETURN n.{id_prop} AS {id_prop}, ID(n) AS _id"""
 
             new_nodes = self.tx.run(create_query, batch=batch)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To ensure the `batch_create_nodes` function's idempotence, we should switch from using `CREATE` to `MERGE`. While `CREATE` isn't inherently idempotent, `MERGE` is, as it combines `CREATE` and `MATCH`, creating a new row only when it doesn't already exist. You can refer to the [Neo4j MERGE documentation](https://neo4j.com/docs/cypher-manual/current/clauses/merge/) for more details on how `MERGE` works.

## Motivation and Context

Closes #89

## How Has This Been Tested?
1. **Repeated Pipeline Execution:**
    - The data pipeline `atlas_probes.py` was executed multiple times without encountering any errors.

2. **Pipeline with New Properties:**
    - Executing the data pipeline `atlas_probes.py` multiple times, including new properties, reflected the changes accurately in the node properties within the Neo4j web interface.

## Screenshots (if appropriate):
https://github.com/InternetHealthReport/internet-yellow-pages/assets/69568555/4dfb5767-182c-4c55-8a6a-8140819e7efc

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.