### PR TITLE
Query function rework

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,11 @@ labels: ""
 assignees: ""
 ---
 
+*NOTE (Delete after reading): There is no need to open bug reports based on
+error messages in the log of the weekly database dump. We usually notice them
+and can judge if a simple rerun of the crawler suffices (e.g., due to a
+temporary connectivity issue), or if there is a bug in the crawler.*
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -190,7 +190,7 @@ class IYP(object):
         set all=False.
         This method commits changes to the database.
         """
-        if type(label) is list and create:
+        if isinstance(label, list) and create:
             raise NotImplementedError('Can not implicitly create multi-label nodes.')
 
         if prop_set and prop_name in prop_formatters:
@@ -280,6 +280,7 @@ class IYP(object):
         #   64497.
         #   The returned id map would be:
         #     {1: x, 2: y}
+
         if isinstance(label, list) and create:
             raise NotImplementedError('Can not implicitly create multi-label nodes.')
 
@@ -307,7 +308,7 @@ class IYP(object):
         # predicate that is contained within the node specification.
         # For id_properties = ['x', 'y'] this will result in
         #   {x: prop.x, y: prop.y}
-        # The RETURN clause is actually only a part, namely
+        # The RETURN clause is actually only a part of it, namely
         #   a.x AS x, a.y AS y
         # for the example above.
         where_clause = ['{']

--- a/iyp/crawlers/apnic/eyeball.py
+++ b/iyp/crawlers/apnic/eyeball.py
@@ -32,8 +32,8 @@ class Crawler(BaseCrawler):
             logging.info(f'processing {country}')
 
             # Get the QID of the country and corresponding ranking
-            cc_qid = self.iyp.get_node('Country', {'country_code': cc}, create=True)
-            ranking_qid = self.iyp.get_node('Ranking', {'name': f'APNIC eyeball estimates ({cc})'}, create=True)
+            cc_qid = self.iyp.get_node('Country', {'country_code': cc})
+            ranking_qid = self.iyp.get_node('Ranking', {'name': f'APNIC eyeball estimates ({cc})'})
             statements = [['COUNTRY', cc_qid, self.reference]]
             self.iyp.add_links(ranking_qid, statements)
 
@@ -57,8 +57,8 @@ class Crawler(BaseCrawler):
                 names.add(asn['autnum'])
 
             # Get node IDs
-            self.asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns, all=False)
-            self.name_id = self.iyp.batch_get_nodes('Name', 'name', names, all=False)
+            self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns, all=False)
+            self.name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', names, all=False)
 
             # Compute links
             country_links = []

--- a/iyp/crawlers/bgpkit/as2rel.py
+++ b/iyp/crawlers/bgpkit/as2rel.py
@@ -34,7 +34,7 @@ class Crawler(BaseCrawler):
             rels.append(rel)
 
         # get ASNs IDs
-        self.asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns)
+        self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
 
         # Compute links
         links = []

--- a/iyp/crawlers/bgpkit/peerstats.py
+++ b/iyp/crawlers/bgpkit/peerstats.py
@@ -63,8 +63,7 @@ class Crawler(BaseCrawler):
             stats = json.load(bz2.open(req.raw))
             collector_qid = self.iyp.get_node(
                 'BGPCollector',
-                {'name': stats['collector'], 'project': stats['project']},
-                create=True
+                {'name': stats['collector'], 'project': stats['project']}
             )
             self.reference['reference_url'] = url
 
@@ -75,7 +74,7 @@ class Crawler(BaseCrawler):
                 asns.add(peer['asn'])
 
             # get ASNs' IDs
-            self.asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns, all=False)
+            self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns, all=False)
 
             # Compute links
             links = []

--- a/iyp/crawlers/bgpkit/pfx2asn.py
+++ b/iyp/crawlers/bgpkit/pfx2asn.py
@@ -37,8 +37,8 @@ class Crawler(BaseCrawler):
 
         logging.info('Pushing nodes to neo4j...\n')
         # get ASNs and prefixes IDs
-        self.asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns)
-        self.prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix', prefixes)
+        self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
+        self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes)
 
         # Compute links
         links = []

--- a/iyp/crawlers/bgptools/anycast_prefixes.py
+++ b/iyp/crawlers/bgptools/anycast_prefixes.py
@@ -76,8 +76,8 @@ class Crawler(BaseCrawler):
                 prefixes.add(line)
                 lines.append(line)
 
-            prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix', prefixes)
-            tag_id = self.iyp.get_node('Tag', {'label': 'Anycast'}, create=True)
+            prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes)
+            tag_id = self.iyp.get_node('Tag', {'label': 'Anycast'})
 
             links = []
             for line in lines:

--- a/iyp/crawlers/bgptools/as_names.py
+++ b/iyp/crawlers/bgptools/as_names.py
@@ -46,8 +46,8 @@ class Crawler(BaseCrawler):
             lines.append([asn, name])
 
         # get ASNs and names IDs
-        self.asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns)
-        self.name_id = self.iyp.batch_get_nodes('Name', 'name', names)
+        self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
+        self.name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', names)
 
         # Compute links
         links = []

--- a/iyp/crawlers/bgptools/tags.py
+++ b/iyp/crawlers/bgptools/tags.py
@@ -63,7 +63,7 @@ class Crawler(BaseCrawler):
                 print(req.text)
                 sys.exit('Error while fetching AS names')
 
-            self.tag_qid = self.iyp.get_node('Tag', {'label': label}, create=True)
+            self.tag_qid = self.iyp.get_node('Tag', {'label': label})
             for line in req.text.splitlines():
                 # skip header
                 if line.startswith('asn'):
@@ -71,7 +71,7 @@ class Crawler(BaseCrawler):
 
                 # Parse given line to get ASN, name, and country code
                 asn, _, _ = line.partition(',')
-                asn_qid = self.iyp.get_node('AS', {'asn': asn[2:]}, create=True)
+                asn_qid = self.iyp.get_node('AS', {'asn': asn[2:]})
                 statements = [['CATEGORIZED', self.tag_qid, self.reference]]  # Set AS name
 
                 try:

--- a/iyp/crawlers/caida/asrank.py
+++ b/iyp/crawlers/caida/asrank.py
@@ -59,10 +59,10 @@ class Crawler(BaseCrawler):
         # Get/create ASNs, names, and country nodes
         print('Pushing nodes.', file=sys.stderr)
         logging.info('Pushing nodes.')
-        self.asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns)
-        self.country_id = self.iyp.batch_get_nodes('Country', 'country_code', countries)
-        self.name_id = self.iyp.batch_get_nodes('Name', 'name', names, all=False)
-        self.asrank_qid = self.iyp.get_node('Ranking', {'name': 'CAIDA ASRank'}, create=True)
+        self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
+        self.country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
+        self.name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', names, all=False)
+        self.asrank_qid = self.iyp.get_node('Ranking', {'name': 'CAIDA ASRank'})
 
         # Compute links
         country_links = list()

--- a/iyp/crawlers/cisco/umbrella_top1M.py
+++ b/iyp/crawlers/cisco/umbrella_top1M.py
@@ -20,7 +20,7 @@ class Crawler(BaseCrawler):
     def run(self):
         """Fetch Umbrella top 1M and push to IYP."""
 
-        self.cisco_qid = self.iyp.get_node('Ranking', {'name': 'Cisco Umbrella Top 1 million'}, create=True)
+        self.cisco_qid = self.iyp.get_node('Ranking', {'name': 'Cisco Umbrella Top 1 million'})
 
         sys.stderr.write('Downloading latest list...\n')
         req = requests.get(URL)
@@ -40,7 +40,7 @@ class Crawler(BaseCrawler):
                     links.append({'src_name': domain, 'dst_id': self.cisco_qid,
                                   'props': [self.reference, {'rank': int(rank)}]})
 
-        name_id = self.iyp.batch_get_nodes('DomainName', 'name', domains)
+        name_id = self.iyp.batch_get_nodes_by_single_prop('DomainName', 'name', domains)
 
         for link in links:
             link['src_id'] = name_id[link['src_name']]

--- a/iyp/crawlers/citizenlab/urldb.py
+++ b/iyp/crawlers/citizenlab/urldb.py
@@ -68,8 +68,8 @@ class Crawler(BaseCrawler):
                     continue
                 lines.append([url, category])
 
-        url_id = self.iyp.batch_get_nodes('URL', 'url', urls)
-        category_id = self.iyp.batch_get_nodes('Tag', 'label', categories)
+        url_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', urls)
+        category_id = self.iyp.batch_get_nodes_by_single_prop('Tag', 'label', categories)
 
         links = []
         for (url, category) in lines:

--- a/iyp/crawlers/cloudflare/dns_top_ases.py
+++ b/iyp/crawlers/cloudflare/dns_top_ases.py
@@ -18,7 +18,7 @@ class Crawler(Crawler):
     def run(self):
         """Push data to IYP."""
 
-        self.as_id = self.iyp.batch_get_nodes('AS', 'asn')
+        self.as_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn')
 
         super().run()
 

--- a/iyp/crawlers/cloudflare/dns_top_locations.py
+++ b/iyp/crawlers/cloudflare/dns_top_locations.py
@@ -103,7 +103,7 @@ class Crawler(BaseCrawler):
         # FIXME this should be called before/separately
         self.fetch()
 
-        self.country_id = self.iyp.batch_get_nodes('Country', 'country_code')
+        self.country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code')
         self.statements = []
 
         tmp_dir = self.get_tmp_dir()

--- a/iyp/crawlers/cloudflare/ranking_bucket.py
+++ b/iyp/crawlers/cloudflare/ranking_bucket.py
@@ -83,7 +83,7 @@ class Crawler(BaseCrawler):
         # domain_ids, but iterate over the domains set instead.
         logging.info(f'Adding/retrieving {len(all_domains)} DomainName nodes.')
         print(f'Adding/retrieving {len(all_domains)} DomainName nodes')
-        domain_ids = self.iyp.batch_get_nodes('DomainName', 'name', all_domains)
+        domain_ids = self.iyp.batch_get_nodes_by_single_prop('DomainName', 'name', all_domains)
 
         for dataset, domains in datasets:
             dataset_title = f'Cloudflare {dataset["title"]}'
@@ -96,7 +96,7 @@ class Crawler(BaseCrawler):
                                                'description': dataset['description'],
                                                'top': dataset['meta']['top']
                                            },
-                                           create=True)
+                                           id_properties={'name'})
 
             # Create RANK relationships
             domain_links = [{'src_id': domain_ids[domain], 'dst_id': ranking_id, 'props': [self.reference]}

--- a/iyp/crawlers/cloudflare/top100.py
+++ b/iyp/crawlers/cloudflare/top100.py
@@ -26,7 +26,7 @@ class Crawler(BaseCrawler):
         """Fetch data and push to IYP."""
 
         self.cf_qid = self.iyp.get_node(
-            'Ranking', {'name': 'Cloudflare top 100 domains'}, create=True)
+            'Ranking', {'name': 'Cloudflare top 100 domains'})
 
         # Fetch data
         headers = {
@@ -52,7 +52,7 @@ class Crawler(BaseCrawler):
 
         # Commit to IYP
         # Get the AS's node ID (create if it is not yet registered) and commit changes
-        domain_qid = self.iyp.get_node('DomainName', {'name': entry['domain']}, create=True)
+        domain_qid = self.iyp.get_node('DomainName', {'name': entry['domain']})
         self.iyp.add_links(domain_qid, statements)
 
 

--- a/iyp/crawlers/emileaben/as_names.py
+++ b/iyp/crawlers/emileaben/as_names.py
@@ -48,8 +48,8 @@ class Crawler(BaseCrawler):
                 as_names.add(as_name)
                 lines.append(values)
 
-            asns_id = self.iyp.batch_get_nodes('AS', 'asn', asns, all=False)
-            as_names_id = self.iyp.batch_get_nodes('Name', 'name', as_names, all=False)
+            asns_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns, all=False)
+            as_names_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', as_names, all=False)
 
             links = []
 

--- a/iyp/crawlers/example/crawler.py
+++ b/iyp/crawlers/example/crawler.py
@@ -44,8 +44,7 @@ class Crawler(BaseCrawler):
             {
                 'example_property_0': value,
                 'example_property_1': value,
-            },
-            create=True
+            }
         )
 
         # set relationship
@@ -53,7 +52,7 @@ class Crawler(BaseCrawler):
 
         # Commit to IYP
         # Get the AS's node ID (create if it is not yet registered) and commit changes
-        as_qid = self.iyp.get_node('AS', {'asn': asn}, create=True)
+        as_qid = self.iyp.get_node('AS', {'asn': asn})
         self.iyp.add_links(as_qid, statements)
 
 

--- a/iyp/crawlers/ihr/__init__.py
+++ b/iyp/crawlers/ihr/__init__.py
@@ -64,7 +64,7 @@ class HegemonyCrawler(BaseCrawler):
         self.csv = lz4Csv(local_filename)
 
         self.timebin = None
-        asn_id = self.iyp.batch_get_nodes('AS', 'asn', set())
+        asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', set())
 
         links = []
 
@@ -83,11 +83,11 @@ class HegemonyCrawler(BaseCrawler):
 
             originasn = int(rec['originasn'])
             if originasn not in asn_id:
-                asn_id[originasn] = self.iyp.get_node('AS', {'asn': originasn}, create=True)
+                asn_id[originasn] = self.iyp.get_node('AS', {'asn': originasn})
 
             asn = int(rec['asn'])
             if asn not in asn_id:
-                asn_id[asn] = self.iyp.get_node('AS', {'asn': asn}, create=True)
+                asn_id[asn] = self.iyp.get_node('AS', {'asn': asn})
 
             links.append({
                 'src_id': asn_id[originasn],

--- a/iyp/crawlers/ihr/country_dependency.py
+++ b/iyp/crawlers/ihr/country_dependency.py
@@ -62,8 +62,7 @@ class Crawler(BaseCrawler):
             country_qid = self.iyp.get_node('Country',
                                             {
                                                 'country_code': cc,
-                                            },
-                                            create=True
+                                            }
                                             )
 
             countryrank_statements = []
@@ -81,8 +80,7 @@ class Crawler(BaseCrawler):
             for metric, weight in [('Total eyeball', 'eyeball'), ('Total AS', 'as')]:
 
                 self.countryrank_qid = self.iyp.get_node('Ranking',
-                                                         {'name': f'IHR country ranking: {metric} ({cc})'},
-                                                         create=True
+                                                         {'name': f'IHR country ranking: {metric} ({cc})'}
                                                          )
                 self.iyp.add_links(self.countryrank_qid, countryrank_statements)
 
@@ -101,7 +99,7 @@ class Crawler(BaseCrawler):
                     asns.add(asn['asn'])
                     asn['rank'] = i + 1
 
-                self.asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns, all=False)
+                self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns, all=False)
 
                 # Compute links
                 for asn in selected:

--- a/iyp/crawlers/ihr/rov.py
+++ b/iyp/crawlers/ihr/rov.py
@@ -74,10 +74,10 @@ class Crawler(BaseCrawler):
         self.csv = lz4Csv(local_filename)
 
         logging.warning('Getting node IDs from neo4j...\n')
-        asn_id = self.iyp.batch_get_nodes('AS', 'asn')
-        prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix')
-        tag_id = self.iyp.batch_get_nodes('Tag', 'label')
-        country_id = self.iyp.batch_get_nodes('Country', 'country_code')
+        asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn')
+        prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix')
+        tag_id = self.iyp.batch_get_nodes_by_single_prop('Tag', 'label')
+        country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code')
 
         orig_links = []
         tag_links = []
@@ -98,26 +98,26 @@ class Crawler(BaseCrawler):
 
             prefix = rec['prefix']
             if prefix not in prefix_id:
-                prefix_id[prefix] = self.iyp.get_node('Prefix', {'prefix': prefix}, create=True)
+                prefix_id[prefix] = self.iyp.get_node('Prefix', {'prefix': prefix})
 
             # make status/country/origin links only for lines where asn=originasn
             if rec['asn_id'] == rec['originasn_id']:
                 # Make sure all nodes exist
                 originasn = int(rec['originasn_id'])
                 if originasn not in asn_id:
-                    asn_id[originasn] = self.iyp.get_node('AS', {'asn': originasn}, create=True)
+                    asn_id[originasn] = self.iyp.get_node('AS', {'asn': originasn})
 
                 rpki_status = 'RPKI ' + rec['rpki_status']
                 if rpki_status not in tag_id:
-                    tag_id[rpki_status] = self.iyp.get_node('Tag', {'label': rpki_status}, create=True)
+                    tag_id[rpki_status] = self.iyp.get_node('Tag', {'label': rpki_status})
 
                 irr_status = 'IRR ' + rec['irr_status']
                 if irr_status not in tag_id:
-                    tag_id[irr_status] = self.iyp.get_node('Tag', {'label': irr_status}, create=True)
+                    tag_id[irr_status] = self.iyp.get_node('Tag', {'label': irr_status})
 
                 cc = rec['country_id']
                 if cc not in country_id:
-                    country_id[cc] = self.iyp.get_node('Country', {'country_code': cc}, create=True)
+                    country_id[cc] = self.iyp.get_node('Country', {'country_code': cc})
 
                 # Compute links
                 orig_links.append({
@@ -147,7 +147,7 @@ class Crawler(BaseCrawler):
             # Dependency links
             asn = int(rec['asn_id'])
             if asn not in asn_id:
-                asn_id[asn] = self.iyp.get_node('AS', {'asn': asn}, create=True)
+                asn_id[asn] = self.iyp.get_node('AS', {'asn': asn})
 
             dep_links.append({
                 'src_id': prefix_id[prefix],

--- a/iyp/crawlers/inetintel/as_org.py
+++ b/iyp/crawlers/inetintel/as_org.py
@@ -108,8 +108,8 @@ class Crawler(BaseCrawler):
                 batch_lines.append([asn, url, sibling_asns, pdb_orgs])
                 count_rows += 1
 
-            asn_id = self.iyp.batch_get_nodes('AS', 'asn', batch_asns, all=False)
-            url_id = self.iyp.batch_get_nodes('URL', 'url', batch_urls, all=False)
+            asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', batch_asns, all=False)
+            url_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', batch_urls, all=False)
 
             asn_to_url_links = []
             asn_to_sibling_asn_links = []

--- a/iyp/crawlers/manrs/members.py
+++ b/iyp/crawlers/manrs/members.py
@@ -23,8 +23,7 @@ class Crawler(BaseCrawler):
 
         self.manrs_qid = self.iyp.get_node(
             'Organization',
-            {'name': 'MANRS'},
-            create=True
+            {'name': 'MANRS'}
         )
 
         # Actions defined by MANRS
@@ -55,7 +54,7 @@ class Crawler(BaseCrawler):
                     'name': action['label'],
                     'description': action['description']
                 },
-                create=True
+                id_properties={'name'}
             )
 
         # Reference information for data pushed to IYP
@@ -94,7 +93,7 @@ class Crawler(BaseCrawler):
 
         # set countries
         for cc in areas.split(';'):
-            country_qid = self.iyp.get_node('Country', {'country_code': cc}, create=True)
+            country_qid = self.iyp.get_node('Country', {'country_code': cc})
             statements.append(['COUNTRY', country_qid, self.reference])
 
         # set actions
@@ -106,7 +105,7 @@ class Crawler(BaseCrawler):
         for asn in asns.split(';'):
             if asn:     # ignore organizations with no ASN
                 # Get the AS QID (create if AS is not yet registered) and commit changes
-                as_qid = self.iyp.get_node('AS', {'asn': str(asn)}, create=True)
+                as_qid = self.iyp.get_node('AS', {'asn': str(asn)})
                 self.iyp.add_links(as_qid, statements)
 
 

--- a/iyp/crawlers/nro/delegated_stats.py
+++ b/iyp/crawlers/nro/delegated_stats.py
@@ -27,7 +27,7 @@ class Crawler(BaseCrawler):
         if req.status_code != 200:
             sys.exit('Error while fetching delegated file')
 
-        asn_id = self.iyp.batch_get_nodes('AS', 'asn')
+        asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn')
 
         # Read delegated-stats file. see documentation:
         # https://www.nro.net/wp-content/uploads/nro-extended-stats-readme5.txt
@@ -66,9 +66,9 @@ class Crawler(BaseCrawler):
 
         # Create all nodes
         logging.warning('Pushing nodes to neo4j...\n')
-        opaqueid_id = self.iyp.batch_get_nodes('OpaqueID', 'id', opaqueids)
-        prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix', prefixes)
-        country_id = self.iyp.batch_get_nodes('Country', 'country_code', countries)
+        opaqueid_id = self.iyp.batch_get_nodes_by_single_prop('OpaqueID', 'id', opaqueids)
+        prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes)
+        country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
 
         # Compute links
         country_links = []

--- a/iyp/crawlers/openintel/__init__.py
+++ b/iyp/crawlers/openintel/__init__.py
@@ -175,11 +175,11 @@ class OpenIntelCrawler(BaseCrawler):
 
         print('Read {} unique A records from {} Parquet file(s).'.format(len(df), len(self.pandas_df_list)))
 
-        domain_id = self.iyp.batch_get_nodes(self.domain_type, 'name', set(df['query_name']))
-        ns_id = self.iyp.batch_get_nodes('AuthoritativeNameServer', 'name',
-                                         set(df[df.ns_address.notnull()]['ns_address']))
-        ip4_id = self.iyp.batch_get_nodes('IP', 'ip', set(df[df.ip4_address.notnull()]['ip4_address']))
-        ip6_id = self.iyp.batch_get_nodes('IP', 'ip', set(df[df.ip6_address.notnull()]['ip6_address']))
+        domain_id = self.iyp.batch_get_nodes_by_single_prop(self.domain_type, 'name', set(df['query_name']))
+        ns_id = self.iyp.batch_get_nodes_by_single_prop('AuthoritativeNameServer', 'name',
+                                                        set(df[df.ns_address.notnull()]['ns_address']))
+        ip4_id = self.iyp.batch_get_nodes_by_single_prop('IP', 'ip', set(df[df.ip4_address.notnull()]['ip4_address']))
+        ip6_id = self.iyp.batch_get_nodes_by_single_prop('IP', 'ip', set(df[df.ip6_address.notnull()]['ip6_address']))
         res_links = []
         mng_links = []
 

--- a/iyp/crawlers/pch/__init__.py
+++ b/iyp/crawlers/pch/__init__.py
@@ -306,8 +306,8 @@ class RoutingSnapshotCrawler(BaseCrawler):
         # Get/push nodes.
         logging.info(f'Fetching {len(ases)} AS and {len(prefixes)} Prefix nodes.')
         print(f'Fetching {len(ases)} AS and {len(prefixes)} Prefix nodes.')
-        as_ids = self.iyp.batch_get_nodes('AS', 'asn', ases, all=False)
-        prefix_ids = self.iyp.batch_get_nodes('Prefix', 'prefix', prefixes, all=False)
+        as_ids = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', ases, all=False)
+        prefix_ids = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
 
         # Push relationships.
         relationships = list()

--- a/iyp/crawlers/peeringdb/fac.py
+++ b/iyp/crawlers/peeringdb/fac.py
@@ -69,11 +69,11 @@ class Crawler(BaseCrawler):
             handle_social_media(fac, websites)
 
         # push nodes
-        self.fac_id = self.iyp.batch_get_nodes('Facility', 'name', facs)
-        self.name_id = self.iyp.batch_get_nodes('Name', 'name', names)
-        self.website_id = self.iyp.batch_get_nodes('URL', 'url', websites)
-        self.country_id = self.iyp.batch_get_nodes('Country', 'country_code', countries)
-        self.facid_id = self.iyp.batch_get_nodes(FACID_LABEL, 'id', facids)
+        self.fac_id = self.iyp.batch_get_nodes_by_single_prop('Facility', 'name', facs)
+        self.name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', names)
+        self.website_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', websites)
+        self.country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
+        self.facid_id = self.iyp.batch_get_nodes_by_single_prop(FACID_LABEL, 'id', facids)
 
         # get organization nodes
         self.org_id = self.iyp.batch_get_node_extid(ORGID_LABEL)

--- a/iyp/crawlers/peeringdb/ix.py
+++ b/iyp/crawlers/peeringdb/ix.py
@@ -96,7 +96,7 @@ class Crawler(BaseCrawler):
         # get organization, country nodes
         self.org_id = self.iyp.batch_get_node_extid(ORGID_LABEL)
         self.fac_id = self.iyp.batch_get_node_extid(FACID_LABEL)
-        self.country_id = self.iyp.batch_get_nodes('Country', 'country_code')
+        self.country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code')
 
         req = self.requests.get(URL_PDB_IXS, headers=self.headers)
         if req.status_code != 200:
@@ -145,8 +145,8 @@ class Crawler(BaseCrawler):
 
         for netfac in self.netfacs:
             if netfac['net_id'] not in net_id:
-                as_qid = self.iyp.get_node('AS', {'asn': netfac['local_asn']}, create=True)
-                extid_qid = self.iyp.get_node(NETID_LABEL, {'id': netfac['net_id']}, create=True)
+                as_qid = self.iyp.get_node('AS', {'asn': netfac['local_asn']})
+                extid_qid = self.iyp.get_node(NETID_LABEL, {'id': netfac['net_id']})
                 links = [['EXTERNAL_ID', extid_qid, self.reference_netfac]]
                 self.iyp.add_links(as_qid, links)
                 net_id[netfac['net_id']] = as_qid
@@ -195,11 +195,11 @@ class Crawler(BaseCrawler):
                         handle_social_media(network, net_website)
 
         # TODO add the type PEERING_LAN? may break the unique constraint
-        self.prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix', prefixes)
-        self.name_id = self.iyp.batch_get_nodes('Name', 'name', net_names)
-        self.website_id = self.iyp.batch_get_nodes('URL', 'url', net_website)
-        self.netid_id = self.iyp.batch_get_nodes(NETID_LABEL, 'id', net_extid)
-        self.asn_id = self.iyp.batch_get_nodes('AS', 'asn', net_asn)
+        self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes)
+        self.name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', net_names)
+        self.website_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', net_website)
+        self.netid_id = self.iyp.batch_get_nodes_by_single_prop(NETID_LABEL, 'id', net_extid)
+        self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', net_asn)
 
         # compute links
         prefix_links = []
@@ -287,10 +287,10 @@ class Crawler(BaseCrawler):
             all_ixs_website.add(ix['website'])
             handle_social_media(ix, all_ixs_website)
 
-        self.ixext_id = self.iyp.batch_get_nodes(IXID_LABEL, 'id', all_ixs_id)
-        self.ix_id = self.iyp.batch_get_nodes('IXP', 'name', all_ixs_name)
-        self.website_id = self.iyp.batch_get_nodes('URL', 'url', all_ixs_website)
-        self.name_id = self.iyp.batch_get_nodes('Name', 'name', all_ixs_name)
+        self.ixext_id = self.iyp.batch_get_nodes_by_single_prop(IXID_LABEL, 'id', all_ixs_id)
+        self.ix_id = self.iyp.batch_get_nodes_by_single_prop('IXP', 'name', all_ixs_name)
+        self.website_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', all_ixs_website)
+        self.name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', all_ixs_name)
 
         # Compute links
         name_links = []

--- a/iyp/crawlers/peeringdb/org.py
+++ b/iyp/crawlers/peeringdb/org.py
@@ -65,11 +65,11 @@ class Crawler(BaseCrawler):
             handle_social_media(org, websites)
 
         # push nodes
-        self.org_id = self.iyp.batch_get_nodes('Organization', 'name', orgs)
-        self.name_id = self.iyp.batch_get_nodes('Name', 'name', names)
-        self.website_id = self.iyp.batch_get_nodes('URL', 'url', websites)
-        self.country_id = self.iyp.batch_get_nodes('Country', 'country_code', countries)
-        self.orgid_id = self.iyp.batch_get_nodes(ORGID_LABEL, 'id', orgids)
+        self.org_id = self.iyp.batch_get_nodes_by_single_prop('Organization', 'name', orgs)
+        self.name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', names)
+        self.website_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', websites)
+        self.country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
+        self.orgid_id = self.iyp.batch_get_nodes_by_single_prop(ORGID_LABEL, 'id', orgids)
 
         # compute links
         name_links = []

--- a/iyp/crawlers/ripe/as_names.py
+++ b/iyp/crawlers/ripe/as_names.py
@@ -44,9 +44,9 @@ class Crawler(BaseCrawler):
             countries.add(cc)
 
         # get node IDs for ASNs, names, and countries
-        asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns)
-        name_id = self.iyp.batch_get_nodes('Name', 'name', names)
-        country_id = self.iyp.batch_get_nodes('Country', 'country_code', countries)
+        asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
+        name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', names)
+        country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
 
         # Compute links
         name_links = []

--- a/iyp/crawlers/ripe/atlas_probes.py
+++ b/iyp/crawlers/ripe/atlas_probes.py
@@ -121,10 +121,10 @@ class Crawler(BaseCrawler):
         probe_id = dict()
         # Each probe is a JSON object with nested fields, so we need to flatten it.
         flattened_probes = [dict(flatdict.FlatterDict(probe, delimiter='_')) for probe in valid_probes]
-        probe_id = self.iyp.batch_create_nodes('AtlasProbe', 'id', flattened_probes)
-        ip_id = self.iyp.batch_get_nodes('IP', 'ip', ips, all=False)
-        as_id = self.iyp.batch_get_nodes('AS', 'asn', ases, all=False)
-        country_id = self.iyp.batch_get_nodes('Country', 'country_code', countries)
+        probe_id = self.iyp.batch_get_nodes('AtlasProbe', flattened_probes, ['id'])
+        ip_id = self.iyp.batch_get_nodes_by_single_prop('IP', 'ip', ips, all=False)
+        as_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', ases, all=False)
+        country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
 
         # compute links
         assigned_links = list()

--- a/iyp/crawlers/ripe/roa.py
+++ b/iyp/crawlers/ripe/roa.py
@@ -67,8 +67,8 @@ class Crawler(BaseCrawler):
                     'end': end})
 
             # get ASNs and prefixes IDs
-            asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns)
-            prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix', set(prefix_info.keys()))
+            asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
+            prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', set(prefix_info.keys()))
 
             links = []
             for prefix, attributes in prefix_info.items():

--- a/iyp/crawlers/stanford/asdb.py
+++ b/iyp/crawlers/stanford/asdb.py
@@ -61,8 +61,8 @@ class Crawler(BaseCrawler):
                     lines.append([asn, category])
 
         # get ASNs and names IDs
-        asn_id = self.iyp.batch_get_nodes('AS', 'asn', asns)
-        category_id = self.iyp.batch_get_nodes('Tag', 'label', categories)
+        asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
+        category_id = self.iyp.batch_get_nodes_by_single_prop('Tag', 'label', categories)
 
         # Compute links
         links = []

--- a/iyp/crawlers/tranco/top1M.py
+++ b/iyp/crawlers/tranco/top1M.py
@@ -20,7 +20,7 @@ class Crawler(BaseCrawler):
     def run(self):
         """Fetch Tranco top 1M and push to IYP."""
 
-        self.tranco_qid = self.iyp.get_node('Ranking', {'name': 'Tranco top 1M'}, create=True)
+        self.tranco_qid = self.iyp.get_node('Ranking', {'name': 'Tranco top 1M'})
 
         sys.stderr.write('Downloading latest list...\n')
         req = requests.get(URL)
@@ -40,7 +40,7 @@ class Crawler(BaseCrawler):
                     links.append({'src_name': domain, 'dst_id': self.tranco_qid,
                                  'props': [self.reference, {'rank': int(rank)}]})
 
-        name_id = self.iyp.batch_get_nodes('DomainName', 'name', domains)
+        name_id = self.iyp.batch_get_nodes_by_single_prop('DomainName', 'name', domains)
 
         for link in links:
             link['src_id'] = name_id[link['src_name']]

--- a/iyp/post/country_information.py
+++ b/iyp/post/country_information.py
@@ -13,7 +13,7 @@ class PostProcess(BasePostProcess):
         """Enrich Country nodes with additional information like alpha-3 codes and
         country names."""
 
-        country_id = self.iyp.batch_get_nodes('Country', 'country_code')
+        country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code')
 
         for country_code in country_id:
             if country_code not in iso3166.countries_by_alpha2:

--- a/iyp/post/dns_hierarchy.py
+++ b/iyp/post/dns_hierarchy.py
@@ -21,7 +21,7 @@ class PostProcess(BasePostProcess):
         print('Building DNS hierarchy.', file=sys.stderr)
 
         # Fetch all existing DomainName nodes.
-        dns_id = self.iyp.batch_get_nodes('DomainName', 'name')
+        dns_id = self.iyp.batch_get_nodes_by_single_prop('DomainName', 'name')
         logging.info(f'Fetched {len(dns_id):,d} DomainName nodes.')
         print(f'Fetched {len(dns_id):,d} DomainName nodes.', file=sys.stderr)
 
@@ -42,7 +42,7 @@ class PostProcess(BasePostProcess):
         # Create new nodes.
         logging.info(f'Creating {len(new_nodes):,d} new DomainName nodes.')
         print(f'Creating {len(new_nodes):,d} new DomainName nodes.', file=sys.stderr)
-        dns_id.update(self.iyp.batch_get_nodes('DomainName', 'name', new_nodes, all=False))
+        dns_id.update(self.iyp.batch_get_nodes_by_single_prop('DomainName', 'name', new_nodes, all=False))
 
         # Build relationships and push to IYP.
         part_of_links = list()

--- a/iyp/post/ip2prefix.py
+++ b/iyp/post/ip2prefix.py
@@ -26,7 +26,7 @@ class PostProcess(BasePostProcess):
         prefix."""
 
         # Get all prefixes in a radix tree
-        prefix_id = self.iyp.batch_get_nodes('Prefix', 'prefix')
+        prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix')
         additional_properties = list()
 
         rtree = radix.Radix()
@@ -41,7 +41,7 @@ class PostProcess(BasePostProcess):
         self.iyp.batch_add_properties(additional_properties)
 
         # Get all IP nodes
-        ip_id = self.iyp.batch_get_nodes('IP', 'ip')
+        ip_id = self.iyp.batch_get_nodes_by_single_prop('IP', 'ip')
 
         # Compute links for IPs
         links = []

--- a/iyp/post/url2domain.py
+++ b/iyp/post/url2domain.py
@@ -11,10 +11,10 @@ class PostProcess(BasePostProcess):
         """Link URLs and their corresponding DomainNames."""
 
         # Get all URL nodes.
-        url_id = self.iyp.batch_get_nodes('URL', 'url')
+        url_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url')
 
         # Get all DomainName Nodes
-        domain_id = self.iyp.batch_get_nodes('DomainName', 'name')
+        domain_id = self.iyp.batch_get_nodes_by_single_prop('DomainName', 'name')
 
         # Compute links
         links = []


### PR DESCRIPTION
This PR reworks the main functions used to query/create nodes. Both get_node and batch_get_nodes functions now have a similar interface and behavior.
Added support for multi-label nodes.

- batch_get_nodes_by_single_prop
  - Renamed from batch_get_nodes
  - Added create parameter for consistency
- get_node
  - Change default value of create parameter to True. There was no instance where this function was called with create=False and now it is consistent with batch_get_nodes.
  - Change interface to be the same as batch_get_nodes.
  - Id properties used as the search predicate must now be specified explicitly instead of being inferred from constraints.
- batch_get_nodes
  - New function that supports querying/creating nodes with multiple properties, where as subset of the properties can be used as the search predicate.
- batch_add_node_label
  - New function to add additional labels to existing nodes.
- batch_create_nodes
  - Deleted due to inflexibility and danger of creating duplicate nodes.