### PR TITLE
Add IANA root zone file crawler

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -69,7 +69,8 @@
             "iyp.crawlers.emileaben.as_names",
             "iyp.crawlers.ripe.atlas_probes",
             "iyp.crawlers.cloudflare.dns_top_locations",
-            "iyp.crawlers.cloudflare.dns_top_ases"
+            "iyp.crawlers.cloudflare.dns_top_ases",
+            "iyp.crawlers.iana.root_zone"
         ],
 
         "post": [

--- a/iyp/crawlers/iana/README.md
+++ b/iyp/crawlers/iana/README.md
@@ -1,0 +1,25 @@
+# IANA -- https://www.iana.org/
+
+The Internet Assigned Numbers Authority (IANA) is responsible for the global
+coordination of the DNS Root, IP addressing, and other Internet protocol resources.
+
+Datasets used by IYP:
+
+- DNS [root zone file](https://www.iana.org/domains/root/files) to retrieve information
+  about authoritative name servers of the top-level domains as well as their IP
+  addresses.
+
+## Graph representation
+
+### Root zone file -  `root_zone.py`
+
+IYP imports `NS`, `A`, and `AAAA` records from the root zone file.
+
+```Cypher
+// NS record
+(:DomainName {name: 'jp'})-[:MANAGED_BY]->(:DomainName:AuthoritativeNameServer {name: 'a.dns.jp'})
+// A record
+(:DomainName:AuthoritativeNameServer {name: 'a.dns.jp'})-[:RESOLVES_TO]->(:IP {ip: '203.119.1.1'})
+// AAAA record
+(:DomainName:AuthoritativeNameServer {name: 'a.dns.jp'})-[:RESOLVES_TO]->(:IP {ip: '2001:dc4::1'})
+```

--- a/iyp/crawlers/iana/root_zone.py
+++ b/iyp/crawlers/iana/root_zone.py
@@ -17,7 +17,7 @@ NAME = 'iana.root_zone'  # should reflect the directory and name of this file
 class Crawler(BaseCrawler):
 
     def run(self):
-        r = requests.get('https://www.internic.net/domain/root.zone')
+        r = requests.get(self.url)
         r.raise_for_status()
 
         lines = [line.split() for line in r.text.splitlines()]

--- a/iyp/crawlers/iana/root_zone.py
+++ b/iyp/crawlers/iana/root_zone.py
@@ -1,0 +1,138 @@
+import argparse
+import ipaddress
+import logging
+import os
+import sys
+
+import requests
+
+from iyp import BaseCrawler
+
+# Organization name and URL to data
+ORG = 'IANA'
+URL = 'https://www.internic.net/domain/root.zone'
+NAME = 'iana.root_zone'  # should reflect the directory and name of this file
+
+
+class Crawler(BaseCrawler):
+
+    def run(self):
+        r = requests.get('https://www.internic.net/domain/root.zone')
+        r.raise_for_status()
+
+        lines = [line.split() for line in r.text.splitlines()]
+
+        domainnames = set()
+        ips = set()
+        authoritativenameservers = set()
+        resolves_to = set()
+        managed_by = set()
+
+        for l in lines:
+            if not l:
+                continue
+            # Each line should have at least five fields:
+            # NAME, TTL, CLASS, TYPE, RDATA
+            if len(l) < 5:
+                logging.warning(f'DNS record line is too short: {l}')
+                print(f'DNS record line is too short: {l}', file=sys.stderr)
+                continue
+            if l[2] != 'IN':
+                logging.warning(f'Unexpected DNS record class: "{l[2]}". Expecting only IN records.')
+                print(f'Unexpected DNS record class: "{l[2]}". Expecting only IN records.', file=sys.stderr)
+                continue
+            record_type = l[3]
+            if record_type not in {'A', 'AAAA', 'NS'}:
+                continue
+            name = l[0].rstrip('.')
+            # We do not have a node for the DNS root ".".
+            if not name:
+                continue
+            rdata = l[4]
+            if record_type == 'NS':
+                # Name server, value has to be a domain name.
+                nsdname = rdata.rstrip('.')
+                if not nsdname:
+                    logging.warning(f'NS record points to root node? {l}')
+                    print(f'NS record points to root node? {l}', file=sys.stderr)
+                    continue
+                if nsdname not in domainnames:
+                    domainnames.add(nsdname)
+                if nsdname not in authoritativenameservers:
+                    authoritativenameservers.add(nsdname)
+                managed_by.add((name, nsdname))
+            else:
+                # A or AAAA record, value has to be an IP address.
+                try:
+                    # This is useful for IPv6 addresses, since the root zone file does
+                    # not do zero compression, for example:
+                    #   a.nic.aaa. 172800 IN AAAA 2001:dcd:1:0:0:0:0:9
+                    # should be 2001:dcd:1::9 instead.
+                    ip = ipaddress.ip_address(rdata).compressed
+                except ValueError as e:
+                    logging.warning(f'Invalid IP address in A/AAAA record: {l}')
+                    logging.warning(e)
+                    print(f'Invalid IP address in A/AAAA record: {l}', file=sys.stderr)
+                    print(e, file=sys.stderr)
+                    continue
+                if ip not in ips:
+                    ips.add(ip)
+                resolves_to.add((name, ip))
+            # Only add now so that in case there is an error in the if/else above, we do
+            # not create a dangling node.
+            if name not in domainnames:
+                domainnames.add(name)
+
+        logging.info(f'Fetching/Creating {len(domainnames)} DomainName nodes')
+        domain_id = self.iyp.batch_get_nodes_by_single_prop('DomainName', 'name', domainnames, all=False)
+        logging.info(f'Fetching/Creating {len(ips)} IP nodes')
+        ip_id = self.iyp.batch_get_nodes_by_single_prop('IP', 'ip', ips, all=False)
+        authoritativenameservers_id = {name: domain_id[name] for name in authoritativenameservers}
+        logging.info(f'Adding AuthoritativeNameServer label to {len(authoritativenameservers_id)} DomainName nodes.')
+        self.iyp.batch_add_node_label(list(authoritativenameservers_id.values()), 'AuthoritativeNameServer')
+
+        logging.info('Computing relationships')
+        resolves_to_relationships = list()
+        for (name, ip) in resolves_to:
+            resolves_to_relationships.append({'src_id': domain_id[name],
+                                              'dst_id': ip_id[ip],
+                                              'props': [self.reference]})
+        managed_by_relationships = list()
+        for (name, nsdname) in managed_by:
+            managed_by_relationships.append({'src_id': domain_id[name],
+                                             'dst_id': authoritativenameservers_id[nsdname],
+                                             'props': [self.reference]})
+        logging.info(f'Pushing {len(resolves_to_relationships)} RESOLVES_TO relationships.')
+        self.iyp.batch_add_links('RESOLVES_TO', resolves_to_relationships)
+        logging.info(f'Pushing {len(managed_by)} MANAGED_BY relationships.')
+        self.iyp.batch_add_links('MANAGED_BY', managed_by_relationships)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--unit-test', action='store_true')
+    args = parser.parse_args()
+
+    scriptname = os.path.basename(sys.argv[0]).replace('/', '_')[0:-3]
+    FORMAT = '%(asctime)s %(levelname)s %(message)s'
+    logging.basicConfig(
+        format=FORMAT,
+        filename='log/' + scriptname + '.log',
+        level=logging.INFO,
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+    logging.info(f'Started: {sys.argv}')
+
+    crawler = Crawler(ORG, URL, NAME)
+    if args.unit_test:
+        crawler.unit_test(logging)
+    else:
+        crawler.run()
+        crawler.close()
+    logging.info(f'Finished: {sys.argv}')
+
+
+if __name__ == '__main__':
+    main()
+    sys.exit(0)

--- a/iyp/crawlers/openintel/__init__.py
+++ b/iyp/crawlers/openintel/__init__.py
@@ -205,22 +205,22 @@ class OpenIntelCrawler(BaseCrawler):
         if self.additional_domain_type:
             print(f'Added "{self.additional_domain_type}" label to {len(additional_id)} nodes.')
 
-        for ind in df.index:
-            domain_qid = domain_id[df['query_name'][ind]]
+        for row in df.itertuples():
+            domain_qid = domain_id[row.query_name]
 
             # A Record
-            if df['response_type'][ind] == 'A' and df['ip4_address'][ind]:
-                ip_qid = ip4_id[df['ip4_address'][ind]]
+            if row.response_type == 'A' and row.ip4_address:
+                ip_qid = ip4_id[row.ip4_address]
                 res_links.append({'src_id': domain_qid, 'dst_id': ip_qid, 'props': [self.reference]})
 
             # AAAA Record
-            elif df['response_type'][ind] == 'AAAA' and df['ip6_address'][ind]:
-                ip_qid = ip6_id[df['ip6_address'][ind]]
+            elif row.response_type == 'AAAA' and row.ip6_address:
+                ip_qid = ip6_id[row.ip6_address]
                 res_links.append({'src_id': domain_qid, 'dst_id': ip_qid, 'props': [self.reference]})
 
             # NS Record
-            elif df['response_type'][ind] == 'NS' and df['ns_address'][ind]:
-                ns_qid = ns_id[df['ns_address'][ind]]
+            elif row.response_type == 'NS' and row.ns_address:
+                ns_qid = ns_id[row.ns_address]
                 mng_links.append({'src_id': domain_qid, 'dst_id': ns_qid, 'props': [self.reference]})
 
         print(f'Computed {len(res_links)} RESOLVES_TO links and {len(mng_links)} MANAGED_BY links')


### PR DESCRIPTION
This PR implements the IANA root zone file crawler and closes #82. Since this is the first crawler that adds multi-label nodes, additional changes to the OpenINTEL crawlers were required to prevent conflicts.

## Description

The IANA root zone file contains NS records for the top-level domains, as well as A/AAAA records for the authoritative name servers.

This is the first crawler that introduces multi-label nodes, namely we now have a combination `DomainName:AuthoritativeNameServer`, since every name server is identified by a domain name. In accordance with this change, this PR updates the other crawler that creates `AuthoritativeNameServer` nodes, namely the OpenINTEL crawler. Without this change there are conflicting constraints.

As part of changing the OpenINTEL crawler this PR also reduces the execution time of the link-computation phase of the crawler by a factor of 10. The current version used an inefficient method for iterating over the data.

## How Has This Been Tested?

These changes have been tested as part of a full database creation and also repeated independently.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

