### PR TITLE
Refactoring `batch_format_link_properties` to Utilize Optional Return Type for in-place Mutation

### DIFF
--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -6,6 +6,7 @@ import pickle
 import sys
 from datetime import datetime, time, timezone
 from shutil import rmtree
+from typing import Optional
 
 from neo4j import GraphDatabase
 
@@ -38,7 +39,7 @@ def format_properties(prop):
     return prop
 
 
-def batch_format_link_properties(links: list, inplace=True) -> list:
+def batch_format_link_properties(links: list, inplace=True) -> Optional[list]:
     """Helper function that applies format_properties to the relationship properties.
 
     Warning: Formats properties in-place to save memory by default.
@@ -50,7 +51,6 @@ def batch_format_link_properties(links: list, inplace=True) -> list:
         for link in links:
             for idx, prop_dict in enumerate(link['props']):
                 link['props'][idx] = format_properties(prop_dict)
-        return links
     return [{'src_id': link['src_id'],
              'dst_id': link['dst_id'],
              'props': [format_properties(d) for d in link['props']]}

--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -51,6 +51,7 @@ def batch_format_link_properties(links: list, inplace=True) -> Optional[list]:
         for link in links:
             for idx, prop_dict in enumerate(link['props']):
                 link['props'][idx] = format_properties(prop_dict)
+        return None
     return [{'src_id': link['src_id'],
              'dst_id': link['dst_id'],
              'props': [format_properties(d) for d in link['props']]}


### PR DESCRIPTION
## Description
The current functionality within [`batch_format_link_properties`](https://github.com/InternetHealthReport/internet-yellow-pages/blob/a6abff3e8131d477b739b266c3d6025b578daf11/iyp/__init__.py#L41-L53) doesn't utilize the returned links when the `inplace` parameter is set to `True`. It's more conventionally sound not to return a value if we're already mutating in place.

## Changes Made
- Removed the return of links from `batch_format_link_properties` when the `inplace` parameter is `True`.
- Utilized `Optional` from the `typing` module to denote the possible absence of a return value when `inplace` is set to `True`.

## How Has This Been Tested?
No alterations to the logic's behavior have been made. Testing ensured that the removal of the return value was correctly implemented, specifically when the `inplace` parameter is `True`.

## Additional References
Python Optional typing hint:
https://docs.python.org/3/library/typing.html#typing.Optional

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

