### PR TITLE
Update `__process_response` to Set `next_url` as `None` for Absent Values in `atlas_probes.py`

### DIFF
--- a/iyp/crawlers/ripe/atlas_probes.py
+++ b/iyp/crawlers/ripe/atlas_probes.py
@@ -50,7 +50,7 @@ class Crawler(BaseCrawler):
         next_url = data['next']
         if not next_url:
             logging.info('Reached end of list')
-            next_url = str()
+            next_url = None
         return next_url, data['results']
 
     def __execute_query(self, url: str):


### PR DESCRIPTION
## Description
In `atlas_probes.py`, update [`__process_response`](https://github.com/InternetHealthReport/internet-yellow-pages/blob/a6abff3e8131d477b739b266c3d6025b578daf11/iyp/crawlers/ripe/atlas_probes.py#L40-L54) to set `next_url` as `None` instead of an empty string (`str()`) to better indicate the absence of a `next_url` value in the crawler pipeline.

## Motivation and Context
This change aligns with Python conventions by using `None` to signify the lack of a value. It improves readability and maintains compatibility since both `None` and an empty string evaluate to `False`.

## How Has This Been Tested?
The script `atlas_probes.py` was run to ensure seamless functionality after the modification. Testing confirmed the script operates without issues with this update.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

