### PR TITLE
Replace sys.exit call with exception handling in crawlers

### DIFF
--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -3,12 +3,11 @@ import glob
 import logging
 import os
 import pickle
-import sys
 from datetime import datetime, time, timezone
 from shutil import rmtree
 from typing import Optional
-import requests
 
+import requests
 from neo4j import GraphDatabase
 
 BATCH_SIZE = 50000
@@ -66,41 +65,47 @@ def dict2str(d, eq=':', pfx=''):
     for key, value in d.items():
         if isinstance(value, str) and '"' in value:
             escaped = value.replace("'", r"\'")
-            data.append(f"{pfx+key}{eq} '{escaped}'")
+            data.append(f"{pfx + key}{eq} '{escaped}'")
         elif isinstance(value, str) or isinstance(value, datetime):
-            data.append(f'{pfx+key}{eq} "{value}"')
+            data.append(f'{pfx + key}{eq} "{value}"')
         elif value is None:
             # Neo4j does not have the concept of empty properties.
             pass
         else:
-            data.append(f'{pfx+key}{eq} {value}')
+            data.append(f'{pfx + key}{eq} {value}')
 
     return '{' + ','.join(data) + '}'
+
 
 class RequestStatusError(requests.HTTPError):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
 
+
 class JSONDecodeError(ValueError):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
+
 
 class MissingKeyError(Exception):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
 
+
 class ConnectionError(requests.exceptions.ConnectionError):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
 
+
 class AddressValueError(ValueError):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
+
 
 class IYP(object):
 

--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -8,7 +8,6 @@ from shutil import rmtree
 from typing import Optional
 
 import requests
-
 from neo4j import GraphDatabase
 
 BATCH_SIZE = 50000

--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -7,6 +7,7 @@ import sys
 from datetime import datetime, time, timezone
 from shutil import rmtree
 from typing import Optional
+import requests
 
 from neo4j import GraphDatabase
 
@@ -76,6 +77,30 @@ def dict2str(d, eq=':', pfx=''):
 
     return '{' + ','.join(data) + '}'
 
+class RequestStatusError(requests.HTTPError):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+class JSONDecodeError(ValueError):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+class MissingKeyError(Exception):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+class ConnectionError(requests.exceptions.ConnectionError):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+class AddressValueError(ValueError):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
 
 class IYP(object):
 
@@ -95,7 +120,7 @@ class IYP(object):
         self.db = GraphDatabase.driver(uri, auth=(self.login, self.password))
 
         if self.db is None:
-            sys.exit('Could not connect to the Neo4j database!')
+            raise ConnectionError('Could not connect to the Neo4j database!')
         # Raises an exception if there is a problem.
         # "Best practice" is to just let the program
         # crash: https://neo4j.com/docs/python-manual/current/connect/

--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -8,6 +8,7 @@ from shutil import rmtree
 from typing import Optional
 
 import requests
+
 from neo4j import GraphDatabase
 
 BATCH_SIZE = 50000

--- a/iyp/crawlers/apnic/eyeball.py
+++ b/iyp/crawlers/apnic/eyeball.py
@@ -6,7 +6,7 @@ import sys
 import iso3166
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # URL to APNIC API
 URL = 'http://v6data.data.labs.apnic.net/ipv6-measurement/Economies/'
@@ -40,7 +40,7 @@ class Crawler(BaseCrawler):
             self.url = URL + f'{cc}/{cc}.asns.json?m={MIN_POP_PERC}'
             req = requests.get(self.url)
             if req.status_code != 200:
-                sys.exit('Error while fetching data for ' + cc)
+                raise RequestStatusError(f'Error while fetching data for {cc}')
 
             asns = set()
             names = set()

--- a/iyp/crawlers/bgp/rv_ris.py
+++ b/iyp/crawlers/bgp/rv_ris.py
@@ -57,7 +57,7 @@ class Crawler(object):
 
             for asn in origin_asns:
                 rnode.data['origin'][asn].add(elem.collector)
-                sys.stderr.write(f'\rProcessed {i+1} BGP messages')
+                sys.stderr.write(f'\rProcessed {i + 1} BGP messages')
 
         sys.stderr.write('\nPushing data to IYP...\n')
 
@@ -65,7 +65,7 @@ class Crawler(object):
         for i, rnode in enumerate(rtree):
             data = rnode.data['origin']
             self.update_entry(rnode.prefix, data)
-            sys.stderr.write(f'\rProcessed {i+1} prefixes')
+            sys.stderr.write(f'\rProcessed {i + 1} prefixes')
 
     def update_entry(self, prefix, originasn_collector):
         """Add the prefix to wikibase if it's not already there and update its

--- a/iyp/crawlers/bgpkit/__init__.py
+++ b/iyp/crawlers/bgpkit/__init__.py
@@ -1,6 +1,5 @@
 import bz2
 import json
-import sys
 
 import requests
 

--- a/iyp/crawlers/bgpkit/__init__.py
+++ b/iyp/crawlers/bgpkit/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 
 class AS2RelCrawler(BaseCrawler):
@@ -20,7 +20,7 @@ class AS2RelCrawler(BaseCrawler):
 
         req = requests.get(self.url, stream=True)
         if req.status_code != 200:
-            sys.exit('Error while fetching AS relationships')
+            raise RequestStatusError('Error while fetching AS relationships')
 
         rels = []
         asns = set()

--- a/iyp/crawlers/bgpkit/peerstats.py
+++ b/iyp/crawlers/bgpkit/peerstats.py
@@ -8,7 +8,7 @@ from datetime import datetime, time, timedelta, timezone
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 MAIN_PAGE = 'https://data.bgpkit.com/peer-stats/'
 URL = 'https://data.bgpkit.com/peer-stats/{collector}/{year}/{month:02d}/peer-stats_{collector}_{year}-{month:02d}-{day:02d}_{epoch}.bz2'  # noqa: E501
@@ -24,7 +24,7 @@ class Crawler(BaseCrawler):
         req = requests.get(MAIN_PAGE)
         if req.status_code != 200:
             logging.error(f'Cannot fetch peer-stats page {req.status_code}: req.text')
-            sys.exit('Error while fetching main page')
+            raise RequestStatusError('Error while fetching main page')
 
         # Find all collectors
         collectors = []

--- a/iyp/crawlers/bgpkit/pfx2asn.py
+++ b/iyp/crawlers/bgpkit/pfx2asn.py
@@ -7,7 +7,7 @@ import sys
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 URL = 'https://data.bgpkit.com/pfx2as/pfx2as-latest.json.bz2'
 ORG = 'BGPKIT'
@@ -22,7 +22,7 @@ class Crawler(BaseCrawler):
 
         req = requests.get(URL, stream=True)
         if req.status_code != 200:
-            sys.exit('Error while fetching pfx2as relationships')
+            raise RequestStatusError('Error while fetching pfx2as relationships')
 
         entries = []
         asns = set()

--- a/iyp/crawlers/bgptools/anycast_prefixes.py
+++ b/iyp/crawlers/bgptools/anycast_prefixes.py
@@ -6,7 +6,7 @@ import tempfile
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError, ConnectionError
 
 # Organization name and URL to data
 ORG = 'BGP.Tools'
@@ -29,10 +29,10 @@ def fetch_dataset(url: str):
         return res
     except requests.exceptions.ConnectionError as e:
         logging.error(e)
-        sys.exit('Connection error while fetching data file')
+        raise ConnectionError('Connection error while fetching data file')
     except requests.exceptions.HTTPError as e:
         logging.error(e)
-        sys.exit('Error while fetching data file')
+        raise RequestStatusError('Error while fetching data file')
 
 
 class Crawler(BaseCrawler):

--- a/iyp/crawlers/bgptools/anycast_prefixes.py
+++ b/iyp/crawlers/bgptools/anycast_prefixes.py
@@ -6,7 +6,7 @@ import tempfile
 
 import requests
 
-from iyp import BaseCrawler, RequestStatusError, ConnectionError
+from iyp import BaseCrawler, ConnectionError, RequestStatusError
 
 # Organization name and URL to data
 ORG = 'BGP.Tools'

--- a/iyp/crawlers/bgptools/as_names.py
+++ b/iyp/crawlers/bgptools/as_names.py
@@ -5,7 +5,7 @@ import sys
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # curl -s https://bgp.tools/asns.csv | head -n 5
 URL = 'https://bgp.tools/asns.csv'
@@ -27,7 +27,7 @@ class Crawler(BaseCrawler):
 
         req = requests.get(URL, headers=self.headers)
         if req.status_code != 200:
-            sys.exit('Error while fetching AS names')
+            raise RequestStatusError('Error while fetching AS names')
 
         lines = []
         asns = set()

--- a/iyp/crawlers/bgptools/tags.py
+++ b/iyp/crawlers/bgptools/tags.py
@@ -6,7 +6,7 @@ from datetime import datetime, time, timezone
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # curl -s https://bgp.tools/asns.csv | head -n 5
 URL = 'https://bgp.tools/tags/'
@@ -61,7 +61,7 @@ class Crawler(BaseCrawler):
             req = requests.get(url, headers=self.headers)
             if req.status_code != 200:
                 print(req.text)
-                sys.exit('Error while fetching AS names')
+                raise RequestStatusError('Error while fetching AS names')
 
             self.tag_qid = self.iyp.get_node('Tag', {'label': label})
             for line in req.text.splitlines():

--- a/iyp/crawlers/caida/asrank.py
+++ b/iyp/crawlers/caida/asrank.py
@@ -26,7 +26,7 @@ class Crawler(BaseCrawler):
         has_next = True
         i = 0
         while has_next:
-            url = URL + f'&offset={i*10000}'
+            url = URL + f'&offset={i * 10000}'
             i += 1
             logging.info(f'Fetching {url}')
             req = requests.get(url)

--- a/iyp/crawlers/caida/asrank.py
+++ b/iyp/crawlers/caida/asrank.py
@@ -7,7 +7,7 @@ import sys
 import flatdict
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # URL to ASRank API
 URL = 'https://api.asrank.caida.org/v2/restful/asns/?first=10000'
@@ -32,8 +32,7 @@ class Crawler(BaseCrawler):
             req = requests.get(url)
             if req.status_code != 200:
                 logging.error(f'Request failed with status: {req.status_code}')
-                # FIXME should raise an exception
-                sys.exit('Error while fetching data from API')
+                raise RequestStatusError('Error while fetching data from API')
 
             ranking = json.loads(req.text)['data']['asns']
             has_next = ranking['pageInfo']['hasNextPage']

--- a/iyp/crawlers/cisco/umbrella_top1M.py
+++ b/iyp/crawlers/cisco/umbrella_top1M.py
@@ -7,7 +7,7 @@ from zipfile import ZipFile
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # URL to Tranco top 1M
 URL = 'http://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip'
@@ -25,7 +25,7 @@ class Crawler(BaseCrawler):
         sys.stderr.write('Downloading latest list...\n')
         req = requests.get(URL)
         if req.status_code != 200:
-            sys.exit('Error while fetching Cisco Umbrella Top 1M csv file')
+            raise RequestStatusError('Error while fetching Cisco Umbrella Top 1M csv file')
 
         links = []
         domains = set()

--- a/iyp/crawlers/citizenlab/urldb.py
+++ b/iyp/crawlers/citizenlab/urldb.py
@@ -6,7 +6,7 @@ import sys
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # Organization name and URL to data
 ORG = 'Citizen Lab'
@@ -30,7 +30,7 @@ class Crawler(BaseCrawler):
 
         if req_for_country_codes.status_code != 200:
             logging.error('Cannot download data {req.status_code}: {req.text}')
-            sys.exit('Error while fetching data file')
+            raise RequestStatusError('Error while fetching data file')
 
         content = req_for_country_codes.content.decode('utf-8')
         csv_data = csv.reader(content.splitlines(), delimiter=',')

--- a/iyp/crawlers/cloudflare/dns_top_locations.py
+++ b/iyp/crawlers/cloudflare/dns_top_locations.py
@@ -116,7 +116,7 @@ class Crawler(BaseCrawler):
                     self.compute_link(domain_top)
 
             if i % 100 == 0:
-                sys.stderr.write(f'Pushing link batch #{int(i/100)}...\r')
+                sys.stderr.write(f'Pushing link batch #{int(i / 100)}...\r')
                 self.iyp.batch_add_links('QUERIED_FROM', self.statements)
                 self.statements = []
 

--- a/iyp/crawlers/cloudflare/ranking_bucket.py
+++ b/iyp/crawlers/cloudflare/ranking_bucket.py
@@ -7,7 +7,7 @@ import sys
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, JSONDecodeError, RequestStatusError
 
 # Organization name and URL to data
 ORG = 'Cloudflare'
@@ -45,12 +45,12 @@ class Crawler(BaseCrawler):
         req = req_session.get(URL_DATASETS)
         if req.status_code != 200:
             logging.error(f'Cannot download data {req.status_code}: {req.text}')
-            sys.exit('Error while fetching data file')
+            raise RequestStatusError('Error while fetching data file')
 
         datasets_json = req.json()
         if 'success' not in datasets_json or not datasets_json['success']:
             logging.error(f'HTTP request succeeded but API returned: {req.text}')
-            sys.exit('Error while fetching data file')
+            raise JSONDecodeError('Error while fetching data file')
 
         # Fetch all datasets first before starting to process them. This way we can
         # get/create all DomainName nodes in one go and then just add the RANK

--- a/iyp/crawlers/cloudflare/top100.py
+++ b/iyp/crawlers/cloudflare/top100.py
@@ -6,7 +6,7 @@ import sys
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # Organization name and URL to data
 ORG = 'Cloudflare'
@@ -37,7 +37,7 @@ class Crawler(BaseCrawler):
         req = requests.get(self.reference['reference_url'], headers=headers)
         if req.status_code != 200:
             print(f'Cannot download data {req.status_code}: {req.text}')
-            sys.exit('Error while fetching data file')
+            raise RequestStatusError('Error while fetching data file')
 
         # Process line one after the other
         for i, _ in enumerate(map(self.update, req.json()['result']['top'])):

--- a/iyp/crawlers/emileaben/as_names.py
+++ b/iyp/crawlers/emileaben/as_names.py
@@ -6,7 +6,7 @@ import tempfile
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # Organization name and URL to data
 ORG = 'emileaben'
@@ -27,10 +27,10 @@ class Crawler(BaseCrawler):
             res = requests.get(URL)
         except requests.exceptions.ConnectionError as e:
             logging.error(e)
-            sys.exit('Connection error while fetching data file')
+            raise ConnectionError('Connection error while fetching data file')
         except requests.exceptions.HTTPError as e:
             logging.error(e)
-            sys.exit('Error while fetching data file')
+            raise RequestStatusError('Error while fetching data file')
         with open(filename, 'w') as file:
             file.write(res.text)
 

--- a/iyp/crawlers/example/crawler.py
+++ b/iyp/crawlers/example/crawler.py
@@ -5,7 +5,7 @@ import sys
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # Organization name and URL to data
 ORG = 'Example Org'
@@ -24,7 +24,7 @@ class Crawler(BaseCrawler):
         req = requests.get(self.reference['reference_url'])
         if req.status_code != 200:
             logging.error('Cannot download data {req.status_code}: {req.text}')
-            sys.exit('Error while fetching data file')
+            raise RequestStatusError('Error while fetching data file')
 
         # Process line one after the other
         for i, line in enumerate(req.text.splitlines()):

--- a/iyp/crawlers/ihr/country_dependency.py
+++ b/iyp/crawlers/ihr/country_dependency.py
@@ -11,7 +11,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # URL to the API
 URL = 'https://ihr.iijlab.net/ihr/api/hegemony/countries/?country={country}&af=4'
@@ -46,7 +46,7 @@ class Crawler(BaseCrawler):
             self.url = URL.format(country=cc)
             req = self.http_session.get(self.url + '&format=json')
             if req.status_code != 200:
-                sys.exit('Error while fetching data for ' + cc)
+                raise RequestStatusError('Error while fetching data for ' + cc)
             data = json.loads(req.text)
             ranking = data['results']
 

--- a/iyp/crawlers/inetintel/as_org.py
+++ b/iyp/crawlers/inetintel/as_org.py
@@ -9,7 +9,7 @@ import pandas as pd
 import requests
 from github import Github
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, ConnectionError, RequestStatusError
 
 
 def get_latest_dataset_url(github_repo: str, data_dir: str, file_extension: str):
@@ -55,10 +55,10 @@ class Crawler(BaseCrawler):
             req = requests.get(URL)
         except requests.exceptions.ConnectionError as e:
             logging.error(e)
-            sys.exit('Connection error while fetching data file')
+            raise ConnectionError('Connection error while fetching data file')
         except requests.exceptions.HTTPError as e:
             logging.error(e)
-            sys.exit('Error while fetching data file')
+            raise RequestStatusError('Error while fetching data file')
 
         with open(self.filename, 'w') as file:
             file.write(req.text)

--- a/iyp/crawlers/manrs/members.py
+++ b/iyp/crawlers/manrs/members.py
@@ -6,7 +6,7 @@ from datetime import datetime, time, timezone
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # URL to MANRS csv file
 URL = 'https://www.manrs.org/wp-json/manrs/v1/csv/4'
@@ -70,7 +70,7 @@ class Crawler(BaseCrawler):
 
         req = requests.get(URL)
         if req.status_code != 200:
-            sys.exit('Error while fetching MANRS csv file')
+            raise RequestStatusError('Error while fetching MANRS csv file')
 
         for i, row in enumerate(req.text.splitlines()):
             # Skip the header

--- a/iyp/crawlers/nro/delegated_stats.py
+++ b/iyp/crawlers/nro/delegated_stats.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # NOTE: this script is not adding new ASNs. It only adds links for existing ASNs
 # Should be run after crawlers that push many ASNs (e.g. ripe.as_names)
@@ -25,7 +25,7 @@ class Crawler(BaseCrawler):
 
         req = requests.get(URL)
         if req.status_code != 200:
-            sys.exit('Error while fetching delegated file')
+            raise RequestStatusError('Error while fetching delegated file')
 
         asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn')
 

--- a/iyp/crawlers/pch/__init__.py
+++ b/iyp/crawlers/pch/__init__.py
@@ -15,7 +15,7 @@ from requests.exceptions import ChunkedEncodingError
 from requests_futures.sessions import FuturesSession
 from urllib3.util.retry import Retry
 
-from iyp import BaseCrawler, CacheHandler, AddressValueError
+from iyp import AddressValueError, BaseCrawler, CacheHandler
 from iyp.crawlers.pch.show_bgp_parser import ShowBGPParser
 
 PARALLEL_DOWNLOADS = 8

--- a/iyp/crawlers/pch/__init__.py
+++ b/iyp/crawlers/pch/__init__.py
@@ -15,7 +15,7 @@ from requests.exceptions import ChunkedEncodingError
 from requests_futures.sessions import FuturesSession
 from urllib3.util.retry import Retry
 
-from iyp import BaseCrawler, CacheHandler
+from iyp import BaseCrawler, CacheHandler, AddressValueError
 from iyp.crawlers.pch.show_bgp_parser import ShowBGPParser
 
 PARALLEL_DOWNLOADS = 8
@@ -47,7 +47,7 @@ class RoutingSnapshotCrawler(BaseCrawler):
         """af: Address family of the crawler. Must be 4 or 6."""
         if af not in (4, 6):
             logging.error(f'Invalid address family: {af}')
-            sys.exit(f'Invalid address family: {af}')
+            raise AddressValueError(f'Invalid address family: {af}')
         self.MAX_LOOKBACK = timedelta(days=7)
         self.af = af
         if self.af == 4:

--- a/iyp/crawlers/pch/show_bgp_parser.py
+++ b/iyp/crawlers/pch/show_bgp_parser.py
@@ -25,7 +25,7 @@ class ShowBGPParser:
         """af: Address family of the parser. Must be 4 or 6."""
         if af not in (4, 6):
             logging.error(f'Invalid address family specified: {af}')
-            sys.exit('Invalid address family specified.')
+            AddressValueError('Invalid address family specified.')
         self.af = af
         self.status_codes = {'s': 'suppressed',
                              'd': 'damped',

--- a/iyp/crawlers/rapid7/forward_dns_v4.py
+++ b/iyp/crawlers/rapid7/forward_dns_v4.py
@@ -122,7 +122,7 @@ class Crawler(object):
                          f'{len(self.wh._domain2qid)} domain names in wiki\n')
         # push data to wiki
         for i, (tld, pfxs) in enumerate(self.tld_pfx.items()):
-            sys.stderr.write(f'\33[2K\rUpdating iyp... {i+1}/{len(self.tld_pfx)}\t{tld} {len(pfxs)} prefixes')
+            sys.stderr.write(f'\33[2K\rUpdating iyp... {i + 1}/{len(self.tld_pfx)}\t{tld} {len(pfxs)} prefixes')
             self.update(tld, pfxs)
 
         sys.stderr.write('\n')

--- a/iyp/crawlers/ripe/as_names.py
+++ b/iyp/crawlers/ripe/as_names.py
@@ -5,7 +5,7 @@ import sys
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 URL = 'https://ftp.ripe.net/ripe/asnames/asn.txt'
 ORG = 'RIPE NCC'
@@ -19,7 +19,7 @@ class Crawler(BaseCrawler):
 
         req = requests.get(URL)
         if req.status_code != 200:
-            sys.exit('Error while fetching AS names')
+            raise RequestStatusError('Error while fetching AS names')
 
         lines = []
         asns = set()

--- a/iyp/crawlers/ripe/atlas_measurements.py
+++ b/iyp/crawlers/ripe/atlas_measurements.py
@@ -10,12 +10,15 @@ import requests
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-from iyp import BaseCrawler, RequestStatusError, JSONDecodeError, MissingKeyError
+
+from iyp import (BaseCrawler, JSONDecodeError, MissingKeyError,
+                 RequestStatusError)
 
 ORG = 'RIPE NCC'
 
 URL = 'https://atlas.ripe.net/api/v2/measurements'
 NAME = 'ripe.atlas_measurements'
+
 
 class Crawler(BaseCrawler):
     def __init__(self, organization, url, name):

--- a/iyp/crawlers/ripe/atlas_measurements.py
+++ b/iyp/crawlers/ripe/atlas_measurements.py
@@ -10,32 +10,12 @@ import requests
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError, JSONDecodeError, MissingKeyError
 
 ORG = 'RIPE NCC'
 
 URL = 'https://atlas.ripe.net/api/v2/measurements'
 NAME = 'ripe.atlas_measurements'
-
-
-class RequestStatusError(requests.HTTPError):
-    def __init__(self, message):
-        self.message = message
-        super().__init__(self.message)
-
-
-class JSONDecodeError(ValueError):
-    def __init__(self, message):
-        self.message = message
-        super().__init__(self.message)
-
-
-class MissingKeyError(Exception):
-    def __init__(self, message):
-        self.message = message
-        super().__init__(self.message)
-
 
 class Crawler(BaseCrawler):
     def __init__(self, organization, url, name):

--- a/iyp/crawlers/ripe/atlas_probes.py
+++ b/iyp/crawlers/ripe/atlas_probes.py
@@ -12,7 +12,7 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError, JSONDecodeError, MissingKeyError
 
 ORG = 'RIPE NCC'
 
@@ -39,13 +39,13 @@ class Crawler(BaseCrawler):
     @staticmethod
     def __process_response(response: requests.Response):
         if response.status_code != requests.codes.ok:
-            sys.exit(f'Request to {response.url} failed with status: {response.status_code}')
+            raise RequestStatusError(f'Request to {response.url} failed with status: {response.status_code}')
         try:
             data = response.json()
         except json.decoder.JSONDecodeError as e:
-            sys.exit(f'Decoding JSON reply from {response.url} failed with exception: {e}')
+            raise RequestStatusError(f'Decoding JSON reply from {response.url} failed with exception: {e}')
         if 'next' not in data or 'results' not in data:
-            sys.exit('"next" or "results" key missing from response data.')
+            raise MissingKeyError('"next" or "results" key missing from response data.')
 
         next_url = data['next']
         if not next_url:

--- a/iyp/crawlers/ripe/atlas_probes.py
+++ b/iyp/crawlers/ripe/atlas_probes.py
@@ -12,7 +12,7 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from iyp import BaseCrawler, RequestStatusError, JSONDecodeError, MissingKeyError
+from iyp import BaseCrawler, MissingKeyError, RequestStatusError
 
 ORG = 'RIPE NCC'
 

--- a/iyp/crawlers/ripe/roa.py
+++ b/iyp/crawlers/ripe/roa.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # URL to RIPE repository
 URL = 'https://ftp.ripe.net/rpki/'
@@ -44,7 +44,7 @@ class Crawler(BaseCrawler):
             logging.info(f'Fetching ROA file: {self.url}')
             req = requests.get(self.url)
             if req.status_code != 200:
-                sys.exit('Error while fetching data for ' + self.url)
+                raise RequestStatusError('Error while fetching data for ' + self.url)
 
             # Aggregate data per prefix
             asns = set()

--- a/iyp/crawlers/spamhaus/asn_drop.py
+++ b/iyp/crawlers/spamhaus/asn_drop.py
@@ -4,6 +4,7 @@ import sys
 import requests
 
 from iyp.wiki.wikihandy import Wikihandy
+from iyp import RequestStatusError
 
 # URL to ASN Drop List
 URL = 'https://www.spamhaus.org/drop/asndrop.txt'
@@ -65,7 +66,7 @@ class Crawler(object):
 
         req = requests.get(URL)
         if req.status_code != 200:
-            sys.exit('Error while fetching the blocklist')
+            raise RequestStatusError('Error while fetching the blocklist')
 
         for i, row in enumerate(req.text.splitlines()):
             # Skip the header

--- a/iyp/crawlers/spamhaus/asn_drop.py
+++ b/iyp/crawlers/spamhaus/asn_drop.py
@@ -3,8 +3,8 @@ import sys
 
 import requests
 
-from iyp.wiki.wikihandy import Wikihandy
 from iyp import RequestStatusError
+from iyp.wiki.wikihandy import Wikihandy
 
 # URL to ASN Drop List
 URL = 'https://www.spamhaus.org/drop/asndrop.txt'
@@ -74,7 +74,7 @@ class Crawler(object):
                 continue
 
             self.update_net(row)
-            sys.stderr.write(f'\rProcessed {i+1} ASes')
+            sys.stderr.write(f'\rProcessed {i + 1} ASes')
         sys.stderr.write('\n')
 
         self.iyp.close()

--- a/iyp/crawlers/spamhaus/prefix_drop.py
+++ b/iyp/crawlers/spamhaus/prefix_drop.py
@@ -4,6 +4,7 @@ import sys
 import requests
 
 from iyp.wiki.wikihandy import Wikihandy
+from iyp import RequestStatusError
 
 # URL to spamhaus data
 URL = 'https://www.spamhaus.org/drop/drop.txt'
@@ -66,7 +67,7 @@ class Crawler(object):
 
         req = requests.get(self.url)
         if req.status_code != 200:
-            sys.exit('Error while fetching the blocklist')
+            raise RequestStatusError('Error while fetching the blocklist')
 
         for i, row in enumerate(req.text.splitlines()):
             # Skip the header

--- a/iyp/crawlers/spamhaus/prefix_drop.py
+++ b/iyp/crawlers/spamhaus/prefix_drop.py
@@ -3,8 +3,8 @@ import sys
 
 import requests
 
-from iyp.wiki.wikihandy import Wikihandy
 from iyp import RequestStatusError
+from iyp.wiki.wikihandy import Wikihandy
 
 # URL to spamhaus data
 URL = 'https://www.spamhaus.org/drop/drop.txt'
@@ -75,7 +75,7 @@ class Crawler(object):
                 continue
 
             self.update_net(row)
-            sys.stderr.write(f'\rProcessed {i+1} prefixes')
+            sys.stderr.write(f'\rProcessed {i + 1} prefixes')
         sys.stderr.write('\n')
 
         self.iyp.close()

--- a/iyp/crawlers/spamhaus/prefix_edrop.py
+++ b/iyp/crawlers/spamhaus/prefix_edrop.py
@@ -3,8 +3,8 @@ import sys
 
 import requests
 
-from iyp.wiki.wikihandy import Wikihandy
 from iyp import RequestStatusError
+from iyp.wiki.wikihandy import Wikihandy
 
 # URL to spamhaus data
 URL = 'https://www.spamhaus.org/drop/edrop.txt'
@@ -72,7 +72,7 @@ class Crawler(object):
                 continue
 
             self.update_net(row)
-            sys.stderr.write(f'\rProcessed {i+1} prefixes')
+            sys.stderr.write(f'\rProcessed {i + 1} prefixes')
         sys.stderr.write('\n')
 
         self.iyp.close()

--- a/iyp/crawlers/spamhaus/prefix_edrop.py
+++ b/iyp/crawlers/spamhaus/prefix_edrop.py
@@ -4,6 +4,7 @@ import sys
 import requests
 
 from iyp.wiki.wikihandy import Wikihandy
+from iyp import RequestStatusError
 
 # URL to spamhaus data
 URL = 'https://www.spamhaus.org/drop/edrop.txt'
@@ -63,7 +64,7 @@ class Crawler(object):
 
         req = requests.get(URL)
         if req.status_code != 200:
-            sys.exit('Error while fetching the blocklist')
+            raise RequestStatusError('Error while fetching the blocklist')
 
         for i, row in enumerate(req.text.splitlines()):
             # Skip the header

--- a/iyp/crawlers/stanford/asdb.py
+++ b/iyp/crawlers/stanford/asdb.py
@@ -10,7 +10,7 @@ import bs4
 import requests
 from bs4 import BeautifulSoup
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 
 def get_latest_asdb_dataset_url(asdb_stanford_data_url: str, file_name_format: str):
@@ -37,7 +37,7 @@ class Crawler(BaseCrawler):
 
         req = requests.get(URL)
         if req.status_code != 200:
-            sys.exit('Error while fetching ASdb')
+            raise RequestStatusError('Error while fetching ASdb')
 
         lines = []
         asns = set()

--- a/iyp/crawlers/tranco/top1M.py
+++ b/iyp/crawlers/tranco/top1M.py
@@ -7,7 +7,7 @@ from zipfile import ZipFile
 
 import requests
 
-from iyp import BaseCrawler
+from iyp import BaseCrawler, RequestStatusError
 
 # URL to Tranco top 1M
 URL = 'https://tranco-list.eu/top-1m.csv.zip'
@@ -25,7 +25,7 @@ class Crawler(BaseCrawler):
         sys.stderr.write('Downloading latest list...\n')
         req = requests.get(URL)
         if req.status_code != 200:
-            sys.exit('Error while fetching Tranco csv file')
+            raise RequestStatusError('Error while fetching Tranco csv file')
 
         links = []
         domains = set()

--- a/iyp/wiki/wikihandy.py
+++ b/iyp/wiki/wikihandy.py
@@ -641,7 +641,7 @@ class Wikihandy(object):
                                 statements=[
                                     [self.get_pid('instance of'), self.get_qid('autonomous system'), []],
                                     [self.get_pid('autonomous system number'), str(asn), []]
-            ])
+                                ])
 
         return qid
 

--- a/iyp/wiki/wikihandy.py
+++ b/iyp/wiki/wikihandy.py
@@ -641,7 +641,7 @@ class Wikihandy(object):
                                 statements=[
                                     [self.get_pid('instance of'), self.get_qid('autonomous system'), []],
                                     [self.get_pid('autonomous system number'), str(asn), []]
-                                ])
+            ])
 
         return qid
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Crawlers raise exception in case of fatal error instead of exiting the program
## Description

<!--- Describe your changes in detail -->
In case of fatal error i.e `httperror`, `jsondecodeerror`, `missingkeyerror`, `connectionerror` crawlers program were exited but instead now exception are raised and they are passed to the `create_db.py` where the exceptions are handled. Created custom error types for consistency purposes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
fixes: issue #70

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

