### PR TITLE
Add expire_after parameter to CachedSession

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,9 @@
 {
+    "cache": {
+        "directory": "tmp/",
+        "duration_in_days": 6
+    },
+
     "peeringdb": {
         "apikey": ""
     },

--- a/iyp/crawlers/peeringdb/fac.py
+++ b/iyp/crawlers/peeringdb/fac.py
@@ -25,8 +25,15 @@ ORGID_LABEL = 'PeeringdbOrgID'
 FACID_LABEL = 'PeeringdbFacID'
 
 API_KEY = ''
+CACHE_DIR = ''
+CACHE_DURATION = requests_cache.DO_NOT_CACHE
 if os.path.exists('config.json'):
-    API_KEY = json.load(open('config.json', 'r'))['peeringdb']['apikey']
+    with open('config.json', 'r') as f:
+        config = json.load(f)
+    API_KEY = config['peeringdb']['apikey']
+    CACHE_DIR = config['cache']['directory']
+    CACHE_DURATION = timedelta(days=config['cache']['duration_in_days'])
+    del config  # Do not leave as a global variable.
 
 
 class Crawler(BaseCrawler):
@@ -34,7 +41,7 @@ class Crawler(BaseCrawler):
         """Initialisation for pushing peeringDB facilities to IYP."""
 
         self.headers = {'Authorization': 'Api-Key ' + API_KEY}
-        self.requests = requests_cache.CachedSession(f'tmp/{ORG}', expire_after=timedelta(days=6))
+        self.requests = requests_cache.CachedSession(os.path.join(CACHE_DIR, ORG), expire_after=CACHE_DURATION)
 
         super().__init__(organization, url, name)
 

--- a/iyp/crawlers/peeringdb/fac.py
+++ b/iyp/crawlers/peeringdb/fac.py
@@ -34,7 +34,7 @@ class Crawler(BaseCrawler):
         """Initialisation for pushing peeringDB facilities to IYP."""
 
         self.headers = {'Authorization': 'Api-Key ' + API_KEY}
-        self.requests = requests_cache.CachedSession(ORG, expire_after=timedelta(days=6))
+        self.requests = requests_cache.CachedSession(f'tmp/{ORG}', expire_after=timedelta(days=6))
 
         super().__init__(organization, url, name)
 

--- a/iyp/crawlers/peeringdb/fac.py
+++ b/iyp/crawlers/peeringdb/fac.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import sys
+from datetime import timedelta
 
 import flatdict
 import iso3166
@@ -33,7 +34,7 @@ class Crawler(BaseCrawler):
         """Initialisation for pushing peeringDB facilities to IYP."""
 
         self.headers = {'Authorization': 'Api-Key ' + API_KEY}
-        self.requests = requests_cache.CachedSession(ORG)
+        self.requests = requests_cache.CachedSession(ORG, expire_after=timedelta(days=6))
 
         super().__init__(organization, url, name)
 

--- a/iyp/crawlers/peeringdb/ix.py
+++ b/iyp/crawlers/peeringdb/ix.py
@@ -34,8 +34,15 @@ NETID_LABEL = 'PeeringdbNetID'
 FACID_LABEL = 'PeeringdbFacID'
 
 API_KEY = ''
+CACHE_DIR = ''
+CACHE_DURATION = requests_cache.DO_NOT_CACHE
 if os.path.exists('config.json'):
-    API_KEY = json.load(open('config.json', 'r'))['peeringdb']['apikey']
+    with open('config.json', 'r') as f:
+        config = json.load(f)
+    API_KEY = config['peeringdb']['apikey']
+    CACHE_DIR = config['cache']['directory']
+    CACHE_DURATION = timedelta(days=config['cache']['duration_in_days'])
+    del config  # Do not leave as a global variable.
 
 
 def handle_social_media(d: dict, website_set: set = None):
@@ -82,7 +89,7 @@ class Crawler(BaseCrawler):
         self.nets = {}
 
         # Using cached queries
-        self.requests = requests_cache.CachedSession(f'tmp/{ORG}', expire_after=timedelta(days=6))
+        self.requests = requests_cache.CachedSession(os.path.join(CACHE_DIR, ORG), expire_after=CACHE_DURATION)
 
         # connection to IYP database
         super().__init__(organization, url, name)

--- a/iyp/crawlers/peeringdb/ix.py
+++ b/iyp/crawlers/peeringdb/ix.py
@@ -82,7 +82,7 @@ class Crawler(BaseCrawler):
         self.nets = {}
 
         # Using cached queries
-        self.requests = requests_cache.CachedSession(ORG, expire_after=timedelta(days=6))
+        self.requests = requests_cache.CachedSession(f'tmp/{ORG}', expire_after=timedelta(days=6))
 
         # connection to IYP database
         super().__init__(organization, url, name)

--- a/iyp/crawlers/peeringdb/ix.py
+++ b/iyp/crawlers/peeringdb/ix.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import sys
-from datetime import datetime, time, timezone
+from datetime import datetime, time, timedelta, timezone
 
 import flatdict
 import requests_cache
@@ -82,7 +82,7 @@ class Crawler(BaseCrawler):
         self.nets = {}
 
         # Using cached queries
-        self.requests = requests_cache.CachedSession(ORG)
+        self.requests = requests_cache.CachedSession(ORG, expire_after=timedelta(days=6))
 
         # connection to IYP database
         super().__init__(organization, url, name)

--- a/iyp/crawlers/peeringdb/org.py
+++ b/iyp/crawlers/peeringdb/org.py
@@ -22,8 +22,15 @@ NAME = 'peeringdb.org'
 ORGID_LABEL = 'PeeringdbOrgID'
 
 API_KEY = ''
+CACHE_DIR = ''
+CACHE_DURATION = requests_cache.DO_NOT_CACHE
 if os.path.exists('config.json'):
-    API_KEY = json.load(open('config.json', 'r'))['peeringdb']['apikey']
+    with open('config.json', 'r') as f:
+        config = json.load(f)
+    API_KEY = config['peeringdb']['apikey']
+    CACHE_DIR = config['cache']['directory']
+    CACHE_DURATION = timedelta(days=config['cache']['duration_in_days'])
+    del config  # Do not leave as a global variable.
 
 
 class Crawler(BaseCrawler):
@@ -31,7 +38,7 @@ class Crawler(BaseCrawler):
         """Initialisation for pushing peeringDB organizations to IYP."""
 
         self.headers = {'Authorization': 'Api-Key ' + API_KEY}
-        self.requests = requests_cache.CachedSession(f'tmp/{ORG}', expire_after=timedelta(days=6))
+        self.requests = requests_cache.CachedSession(os.path.join(CACHE_DIR, ORG), expire_after=CACHE_DURATION)
 
         super().__init__(organization, url, name)
 

--- a/iyp/crawlers/peeringdb/org.py
+++ b/iyp/crawlers/peeringdb/org.py
@@ -31,7 +31,7 @@ class Crawler(BaseCrawler):
         """Initialisation for pushing peeringDB organizations to IYP."""
 
         self.headers = {'Authorization': 'Api-Key ' + API_KEY}
-        self.requests = requests_cache.CachedSession(ORG, expire_after=timedelta(days=6))
+        self.requests = requests_cache.CachedSession(f'tmp/{ORG}', expire_after=timedelta(days=6))
 
         super().__init__(organization, url, name)
 

--- a/iyp/crawlers/peeringdb/org.py
+++ b/iyp/crawlers/peeringdb/org.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import sys
+from datetime import timedelta
 
 import flatdict
 import iso3166
@@ -30,7 +31,7 @@ class Crawler(BaseCrawler):
         """Initialisation for pushing peeringDB organizations to IYP."""
 
         self.headers = {'Authorization': 'Api-Key ' + API_KEY}
-        self.requests = requests_cache.CachedSession(ORG)
+        self.requests = requests_cache.CachedSession(ORG, expire_after=timedelta(days=6))
 
         super().__init__(organization, url, name)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The cache of the PeeringDB crawler now expires after six days. Therefore, the weekly dump will always fetch fresh data.

## Motivation and Context

Fixes #114 .

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

