### PR TITLE
Add OpenINTEL rDNS crawler and rename dns_dependency crawler to dnsgraph

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -83,8 +83,9 @@
             "iyp.crawlers.alice_lg.linx",
             "iyp.crawlers.alice_lg.megaport",
             "iyp.crawlers.alice_lg.netnod",
-            "iyp.crawlers.openintel.dns_dependency_nl",
-            "iyp.crawlers.openintel.dns_dependency_jp",
+            "iyp.crawlers.openintel.dnsgraph_nl",
+            "iyp.crawlers.openintel.dnsgraph_jp",
+            "iyp.crawlers.openintel.dnsgraph_rdns",
             "iyp.crawlers.cloudflare.dns_top_locations",
             "iyp.crawlers.cloudflare.dns_top_ases"
         ],

--- a/iyp/crawlers/openintel/__init__.py
+++ b/iyp/crawlers/openintel/__init__.py
@@ -239,7 +239,7 @@ class OpenIntelCrawler(BaseCrawler):
         self.iyp.batch_add_links('PART_OF', partof_links)
 
 
-class DnsDependencyCrawler(BaseCrawler):
+class DnsgraphCrawler(BaseCrawler):
 
     def __init__(self, organization, url, name):
         super().__init__(organization, url, name)
@@ -270,6 +270,7 @@ class DnsDependencyCrawler(BaseCrawler):
             base_url = f'{self.reference["reference_url_data"]}/year={year}/week={week}'
             probe_url = f'{base_url}/connections.json.gz'
             if requests.head(probe_url).ok:
+                logging.info(base_url)
                 logging.info(f'Using year={year}/week={week} ({current_date.strftime("%Y-%m-%d")})')
                 break
         else:

--- a/iyp/crawlers/openintel/dnsgraph_jp.py
+++ b/iyp/crawlers/openintel/dnsgraph_jp.py
@@ -1,0 +1,45 @@
+import argparse
+import logging
+import os
+import sys
+
+from iyp.crawlers.openintel import DnsgraphCrawler
+
+URL = 'https://storage.dacs.utwente.nl/sommeser-dnsdep/JP'
+ORG = 'OpenINTEL'
+NAME = 'openintel.dnsgraph_jp'
+
+
+class Crawler(DnsgraphCrawler):
+    def __init__(self, organization, url, name):
+        super().__init__(organization, url, name)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--unit-test', action='store_true')
+    args = parser.parse_args()
+
+    scriptname = os.path.basename(sys.argv[0]).replace('/', '_')[0:-3]
+    FORMAT = '%(asctime)s %(levelname)s %(message)s'
+    logging.basicConfig(
+        format=FORMAT,
+        filename='log/' + scriptname + '.log',
+        level=logging.INFO,
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+    logging.info(f'Started: {sys.argv}')
+
+    crawler = Crawler(ORG, URL, NAME)
+    if args.unit_test:
+        crawler.unit_test(logging)
+    else:
+        crawler.run()
+        crawler.close()
+    logging.info(f'Finished: {sys.argv}')
+
+
+if __name__ == '__main__':
+    main()
+    sys.exit(0)

--- a/iyp/crawlers/openintel/dnsgraph_nl.py
+++ b/iyp/crawlers/openintel/dnsgraph_nl.py
@@ -3,14 +3,14 @@ import logging
 import os
 import sys
 
-from iyp.crawlers.openintel import DnsDependencyCrawler
+from iyp.crawlers.openintel import DnsgraphCrawler
 
-URL = 'https://storage.dacs.utwente.nl/sommeser-dnsdep/JP'
+URL = 'https://storage.dacs.utwente.nl/sommeser-dnsdep/NL'
 ORG = 'OpenINTEL'
-NAME = 'openintel.dns_dependency_jp'
+NAME = 'openintel.dnsgraph_nl'
 
 
-class Crawler(DnsDependencyCrawler):
+class Crawler(DnsgraphCrawler):
     def __init__(self, organization, url, name):
         super().__init__(organization, url, name)
 

--- a/iyp/crawlers/openintel/dnsgraph_rdns.py
+++ b/iyp/crawlers/openintel/dnsgraph_rdns.py
@@ -3,14 +3,14 @@ import logging
 import os
 import sys
 
-from iyp.crawlers.openintel import DnsDependencyCrawler
+from iyp.crawlers.openintel import DnsgraphCrawler
 
-URL = 'https://storage.dacs.utwente.nl/sommeser-dnsdep/NL'
+URL = 'https://storage.dacs.utwente.nl/sommeser-dnsdep/RDNS'
 ORG = 'OpenINTEL'
-NAME = 'openintel.dns_dependency_nl'
+NAME = 'openintel.dnsgraph_rdns'
 
 
-class Crawler(DnsDependencyCrawler):
+class Crawler(DnsgraphCrawler):
     def __init__(self, organization, url, name):
         super().__init__(organization, url, name)
 


### PR DESCRIPTION
We have an additional dataset that is based on rDNS data (which will be implemented via a different PR). Also we were not happy with the name of the dns_dependency crawler, so we renamed it.

## How Has This Been Tested?

I ran the dnsgraph_rdns crawler once, the rest is only refactoring.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

