### PR TITLE
Logging rework

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -38,7 +38,7 @@ def main():
     os.makedirs(dump_dir, exist_ok=True)
 
     # Initialize logging
-    FORMAT = '%(asctime)s %(processName)s %(message)s'
+    FORMAT = '%(asctime)s %(levelname)s %(message)s'
     logging.basicConfig(
         format=FORMAT,
         filename=os.path.join(dump_dir, f'iyp-{date}.log'),
@@ -59,7 +59,7 @@ def main():
 
     # ######### Start a new docker image ##########
 
-    logging.warning('Starting new container...')
+    logging.info('Starting new container...')
     container = client.containers.run(
         'neo4j:' + NEO4J_VERSION,
         name=f'iyp-{date}',
@@ -142,7 +142,7 @@ def main():
             send_email(relation_count_error)
         except Exception as e:
             no_error = False
-            logging.error('crawler crashed!')
+            logging.error('Crawler crashed!')
             status[module_name] = e
             send_email(e)
 
@@ -162,7 +162,7 @@ def main():
 
         except Exception as e:
             no_error = False
-            logging.error('crawler crashed!')
+            logging.error('Crawler crashed!')
             logging.error(e)
             status[module_name] = e
 

--- a/iyp/crawlers/alice_lg/__init__.py
+++ b/iyp/crawlers/alice_lg/__init__.py
@@ -319,15 +319,14 @@ class Crawler(BaseCrawler):
             if failed_neighbors:
                 logging.warning(f'Failed to fetch routes for {len(failed_neighbors)} neighbors: {failed_neighbors}')
             if failed_pages:
-                logging.warning(
-                    f'Failed to fetch {sum(failed_pages.values())} pages for {len(failed_pages)} neighbors:')
+                logging.warning(f'Failed to fetch {sum(failed_pages.values())} pages for {len(failed_pages)} '
+                                f'neighbors:')
                 for key, count in failed_pages.items():
                     logging.warning(f'  {key}: {count}')
 
     def fetch(self) -> None:
         tmp_dir = self.get_tmp_dir()
         if not os.path.exists(tmp_dir):
-            logging.info(f'Creating tmp dir: {tmp_dir}')
             self.create_tmp_dir()
 
         self.__fetch_routeservers()
@@ -360,7 +359,7 @@ class Crawler(BaseCrawler):
             member_ip = neighbor['address']
             n = peering_lans.search_best(member_ip)
             if n is None:
-                logging.warning(f'Failed to map member IP to peering LAN: {member_ip}')
+                logging.debug(f'Failed to map member IP to peering LAN: {member_ip}')
                 continue
             member_asn = neighbor['asn']
             if not member_asn or not isinstance(member_asn, int):
@@ -419,11 +418,9 @@ class Crawler(BaseCrawler):
                                            'props': [flattened_route, self.reference.copy()]})
 
         # Get/create nodes.
-        logging.info(f'Getting {len(asns)} AS nodes.')
         asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns, all=False)
         prefix_id = dict()
         if prefixes:
-            logging.info(f'Getting {len(prefixes)} Prefix nodes.')
             prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
 
         # Translate raw values to QID.
@@ -437,11 +434,9 @@ class Crawler(BaseCrawler):
             relationship['dst_id'] = prefix_id[prefix]
 
         # Push relationships.
-        logging.info(f'Pushing {len(member_of_rels)} MEMBER_OF relationships.')
         self.iyp.batch_add_links('MEMBER_OF', member_of_rels)
         if originate_rels:
-            logging.info(f'Pushing {len(originate_rels)} ORIGINATE relationships.')
             self.iyp.batch_add_links('ORIGINATE', originate_rels)
 
     def unit_test(self):
-        return super().unit_test(['MEMBER_OF', 'ORIGINATE', 'MANAGED_BY'])
+        return super().unit_test(['MEMBER_OF'])

--- a/iyp/crawlers/apnic/eyeball.py
+++ b/iyp/crawlers/apnic/eyeball.py
@@ -28,8 +28,9 @@ class Crawler(BaseCrawler):
 
         processed_asn = set()
 
+        logging.info(f'Processing {len(self.countries)} countries...')
         for cc, country in self.countries.items():
-            logging.info(f'processing {country}')
+            logging.debug(f'processing {country}')
 
             # Get the QID of the country and corresponding ranking
             cc_qid = self.iyp.get_node('Country', {'country_code': cc})
@@ -46,7 +47,7 @@ class Crawler(BaseCrawler):
             names = set()
 
             ranking = req.json()
-            logging.info(f'{len(ranking)} eyeball ASes')
+            logging.debug(f'{len(ranking)} eyeball ASes')
 
             # Collect all ASNs and names
             # and make sure the ranking is sorted and add rank field

--- a/iyp/crawlers/bgpkit/pfx2asn.py
+++ b/iyp/crawlers/bgpkit/pfx2asn.py
@@ -45,7 +45,6 @@ class Crawler(BaseCrawler):
 
         req.close()
 
-        logging.info('Pushing nodes to neo4j...')
         # get ASNs and prefixes IDs
         self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
         self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes)
@@ -58,7 +57,6 @@ class Crawler(BaseCrawler):
 
             links.append({'src_id': asn_qid, 'dst_id': prefix_qid, 'props': [self.reference, entry]})
 
-        logging.info('Pushing links to neo4j...')
         # Push all links to IYP
         self.iyp.batch_add_links('ORIGINATE', links)
 

--- a/iyp/crawlers/bgptools/anycast_prefixes.py
+++ b/iyp/crawlers/bgptools/anycast_prefixes.py
@@ -65,14 +65,12 @@ class Crawler(BaseCrawler):
         ipv4_prefixes_response = fetch_dataset(ipv4_prefixes_url)
         logging.info('IPv4 prefixes fetched successfully.')
         self.update(ipv4_prefixes_response, ipv4_prefixes_filename)
-        logging.info('IPv4 prefixes pushed to IYP.')
 
         self.reference['reference_url_data'] = ipv6_prefixes_url
         self.reference['reference_time_modification'] = get_commit_datetime(self.repo, self.v6_file)
         ipv6_prefixes_response = fetch_dataset(ipv6_prefixes_url)
         logging.info('IPv6 prefixes fetched successfully.')
         self.update(ipv6_prefixes_response, ipv6_prefixes_filename)
-        logging.info('IPv6 prefixes pushed to IYP.')
 
     def update(self, res, filename: str):
         with open(filename, 'w') as file:

--- a/iyp/crawlers/bgptools/tags.py
+++ b/iyp/crawlers/bgptools/tags.py
@@ -60,7 +60,7 @@ class Crawler(BaseCrawler):
 
             req = requests.get(url, headers=self.headers)
             if req.status_code != 200:
-                print(req.text)
+                logging.error(req.text)
                 raise RequestStatusError('Error while fetching AS names')
 
             self.tag_qid = self.iyp.get_node('Tag', {'label': label})
@@ -74,14 +74,8 @@ class Crawler(BaseCrawler):
                 asn_qid = self.iyp.get_node('AS', {'asn': asn[2:]})
                 statements = [['CATEGORIZED', self.tag_qid, self.reference]]  # Set AS name
 
-                try:
-                    # Update AS name and country
-                    self.iyp.add_links(asn_qid, statements)
-
-                except Exception as error:
-                    # print errors and continue running
-                    print('Error for: ', line)
-                    print(error)
+                # Update AS name and country
+                self.iyp.add_links(asn_qid, statements)
 
     def unit_test(self):
         return super().unit_test(['CATEGORIZED'])

--- a/iyp/crawlers/caida/asrank.py
+++ b/iyp/crawlers/caida/asrank.py
@@ -22,16 +22,15 @@ class Crawler(BaseCrawler):
 
     def run(self):
         """Fetch networks information from ASRank and push to IYP."""
-        print('Fetching CAIDA AS Rank', file=sys.stderr)
-
         nodes = list()
 
         has_next = True
         i = 0
+        logging.info('Fetching AS Ranks...')
         while has_next:
             url = URL + f'&offset={i * 10000}'
             i += 1
-            logging.info(f'Fetching {url}')
+            logging.debug(f'Fetching {url}')
             req = requests.get(url)
             if req.status_code != 200:
                 logging.error(f'Request failed with status: {req.status_code}')
@@ -42,7 +41,6 @@ class Crawler(BaseCrawler):
 
             nodes += ranking['edges']
 
-        print(f'Fetched {len(nodes):,d} ranks.', file=sys.stderr)
         logging.info(f'Fetched {len(nodes):,d} ranks.')
 
         # Collect all ASNs, names, and countries
@@ -59,8 +57,6 @@ class Crawler(BaseCrawler):
             asns.add(int(asn['asn']))
 
         # Get/create ASNs, names, and country nodes
-        print('Pushing nodes.', file=sys.stderr)
-        logging.info('Pushing nodes.')
         self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
         self.country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
         self.name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', names, all=False)
@@ -94,8 +90,6 @@ class Crawler(BaseCrawler):
             rank_links.append({'src_id': asn_qid, 'dst_id': self.asrank_qid, 'props': [self.reference, flat_asn]})
 
         # Push all links to IYP
-        print('Pushing links.', file=sys.stderr)
-        logging.info('Pushing links.')
         self.iyp.batch_add_links('NAME', name_links)
         self.iyp.batch_add_links('COUNTRY', country_links)
         self.iyp.batch_add_links('RANK', rank_links)

--- a/iyp/crawlers/caida/ix_asns.py
+++ b/iyp/crawlers/caida/ix_asns.py
@@ -38,7 +38,7 @@ class Crawler(BaseCrawler):
             raise Exception('No recent CAIDA ix-asns file available')
         date = date.datetime.replace(day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
 
-        logging.info('going to use this URL: ' + url)
+        logging.info(f'Fetching data from: {url}')
         super().__init__(organization, url, name)
         self.reference['reference_url_info'] = 'https://publicdata.caida.org/datasets/ixps/README.txt'
         self.reference['reference_time_modification'] = date

--- a/iyp/crawlers/cisco/umbrella_top1m.py
+++ b/iyp/crawlers/cisco/umbrella_top1m.py
@@ -44,7 +44,7 @@ class Crawler(BaseCrawler):
         # date now points to the last available historical file , which means the
         # current file is the day after this date.
         self.reference['reference_time_modification'] = date + timedelta(days=1)
-        logging.info(self.reference)
+        logging.info(f'Got list for date {self.reference["reference_time_modification"].strftime("%Y-%m-%d")}')
 
     def run(self):
         """Fetch Umbrella top 1M and push to IYP."""
@@ -69,7 +69,6 @@ class Crawler(BaseCrawler):
                     links.append({'src_name': domain, 'dst_id': self.cisco_qid,
                                   'props': [self.reference, {'rank': int(rank)}]})
 
-        logging.info('Fetching DomainName/HostName nodes...')
         domain_id = self.iyp.batch_get_nodes_by_single_prop('DomainName', 'name')
         host_id = self.iyp.batch_get_nodes_by_single_prop('HostName', 'name')
 
@@ -103,10 +102,8 @@ class Crawler(BaseCrawler):
                     new_host_names.add(name)
 
         if new_domain_names:
-            logging.info(f'Pushing {len(new_domain_names)} additional DomainName nodes...')
             domain_id.update(self.iyp.batch_get_nodes_by_single_prop('DomainName', 'name', new_domain_names, all=False))
         if new_host_names:
-            logging.info(f'Pushing {len(new_host_names)} additional HostName nodes...')
             host_id.update(self.iyp.batch_get_nodes_by_single_prop('HostName', 'name', new_host_names, all=False))
 
         for link in unprocessed_links:
@@ -120,7 +117,6 @@ class Crawler(BaseCrawler):
             processed_links.append(link)
 
         # Push all links to IYP
-        logging.info(f'Pushing {len(processed_links)} RANK relationships...')
         self.iyp.batch_add_links('RANK', processed_links)
 
     def unit_test(self):

--- a/iyp/crawlers/cloudflare/dns_top_locations.py
+++ b/iyp/crawlers/cloudflare/dns_top_locations.py
@@ -138,14 +138,11 @@ class Crawler(BaseCrawler):
                     self.compute_link(domain_top)
 
             if i % 100 == 0:
-                sys.stderr.write(f'Pushing link batch #{int(i / 100)}...\r')
                 self.iyp.batch_add_links('QUERIED_FROM', self.statements)
                 self.statements = []
 
         if self.statements:
             self.iyp.batch_add_links('QUERIED_FROM', self.statements)
-
-        sys.stderr.write('\n')
 
     def compute_link(self, param):
         """Compute link for the given domain name' top countries and corresponding

--- a/iyp/crawlers/cloudflare/ranking_bucket.py
+++ b/iyp/crawlers/cloudflare/ranking_bucket.py
@@ -98,14 +98,11 @@ class Crawler(BaseCrawler):
         # Note: Since we do not specify all=False in batch_get_nodes we will get the IDs
         # of _all_ DomainName nodes, so we must not create relationships for all
         # domain_ids, but iterate over the domains set instead.
-        logging.info(f'Adding/retrieving {len(all_domains)} DomainName nodes.')
-        print(f'Adding/retrieving {len(all_domains)} DomainName nodes')
         domain_ids = self.iyp.batch_get_nodes_by_single_prop('DomainName', 'name', all_domains)
 
         for dataset, domains in datasets:
             dataset_title = f'Cloudflare {dataset["title"]}'
             logging.info(f'Processing dataset: {dataset_title}')
-            print(f'Processing dataset: {dataset_title}')
             ranking_id = self.iyp.get_node('Ranking',
                                            {
                                                'name': dataset_title,
@@ -119,7 +116,6 @@ class Crawler(BaseCrawler):
                             for domain in domains]
             if domain_links:
                 # Push RANK relationships to IYP
-                print(f'Adding {len(domain_links)} RANK relationships', file=sys.stderr)
                 self.iyp.batch_add_links('RANK', domain_links)
 
     def unit_test(self):

--- a/iyp/crawlers/cloudflare/top100.py
+++ b/iyp/crawlers/cloudflare/top100.py
@@ -43,7 +43,7 @@ class Crawler(BaseCrawler):
 
         req = requests.get(self.reference['reference_url_data'], headers=headers)
         if req.status_code != 200:
-            print(f'Cannot download data {req.status_code}: {req.text}')
+            logging.error(f'Cannot download data {req.status_code}: {req.text}')
             raise RequestStatusError(f'Error while fetching data file: {req.status_code}')
 
         results = req.json()['result']
@@ -56,9 +56,8 @@ class Crawler(BaseCrawler):
             logging.warning(f'Failed to get modification time: {e}')
 
         # Process line one after the other
-        for i, _ in enumerate(map(self.update, results['top'])):
-            sys.stderr.write(f'\rProcessed {i} lines')
-        sys.stderr.write('\n')
+        processed = list(map(self.update, results['top']))
+        logging.info(f'Processed {len(processed)} lines')
 
     def update(self, entry):
         """Add the entry to IYP if it's not already there and update its properties."""

--- a/iyp/crawlers/iana/root_zone.py
+++ b/iyp/crawlers/iana/root_zone.py
@@ -35,11 +35,9 @@ class Crawler(BaseCrawler):
             # NAME, TTL, CLASS, TYPE, RDATA
             if len(l) < 5:
                 logging.warning(f'DNS record line is too short: {l}')
-                print(f'DNS record line is too short: {l}', file=sys.stderr)
                 continue
             if l[2] != 'IN':
                 logging.warning(f'Unexpected DNS record class: "{l[2]}". Expecting only IN records.')
-                print(f'Unexpected DNS record class: "{l[2]}". Expecting only IN records.', file=sys.stderr)
                 continue
             record_type = l[3]
             if record_type not in {'A', 'AAAA', 'NS'}:
@@ -54,7 +52,6 @@ class Crawler(BaseCrawler):
                 nsdname = rdata.rstrip('.')
                 if not nsdname:
                     logging.warning(f'NS record points to root node? {l}')
-                    print(f'NS record points to root node? {l}', file=sys.stderr)
                     continue
                 if nsdname not in domainnames:
                     domainnames.add(nsdname)
@@ -72,8 +69,6 @@ class Crawler(BaseCrawler):
                 except ValueError as e:
                     logging.warning(f'Invalid IP address in A/AAAA record: {l}')
                     logging.warning(e)
-                    print(f'Invalid IP address in A/AAAA record: {l}', file=sys.stderr)
-                    print(e, file=sys.stderr)
                     continue
                 if ip not in ips:
                     ips.add(ip)

--- a/iyp/crawlers/ihr/README.md
+++ b/iyp/crawlers/ihr/README.md
@@ -73,5 +73,4 @@ The country geo-location is provided by Maxmind.
 
 ## Dependence
 
-`rov.py` assumes ASes and prefixes are already registered in the database, it becomes very slow if
-this is not the case. Running `bgpkit.pfx2asn` before makes it much faster.
+These crawlers are not depending on other crawlers.

--- a/iyp/crawlers/ihr/local_hegemony_v4.py
+++ b/iyp/crawlers/ihr/local_hegemony_v4.py
@@ -6,9 +6,7 @@ import sys
 from iyp.crawlers.ihr import HegemonyCrawler
 
 # URL to the API
-URL = ('https://ihr-archive.iijlab.net/ihr/hegemony/ipv4/local/'
-       '{year}/{month:02d}/{day:02d}/'
-       'ihr_hegemony_ipv4_local_{year}-{month:02d}-{day:02d}.csv.lz4')
+URL = 'https://ihr-archive.iijlab.net/ihr/hegemony/ipv4/local/%Y/%m/%d/ihr_hegemony_ipv4_local_%Y-%m-%d.csv.lz4'
 ORG = 'IHR'
 NAME = 'ihr.local_hegemony_v4'
 

--- a/iyp/crawlers/ihr/local_hegemony_v6.py
+++ b/iyp/crawlers/ihr/local_hegemony_v6.py
@@ -6,9 +6,7 @@ import sys
 from iyp.crawlers.ihr import HegemonyCrawler
 
 # URL to the API
-URL = ('https://ihr-archive.iijlab.net/ihr/hegemony/ipv6/local/'
-       '{year}/{month:02d}/{day:02d}/'
-       'ihr_hegemony_ipv6_local_{year}-{month:02d}-{day:02d}.csv.lz4')
+URL = 'https://ihr-archive.iijlab.net/ihr/hegemony/ipv6/local/%Y/%m/%d/ihr_hegemony_ipv6_local_%Y-%m-%d.csv.lz4'
 ORG = 'IHR'
 NAME = 'ihr.local_hegemony_v6'
 

--- a/iyp/crawlers/inetintel/as_org.py
+++ b/iyp/crawlers/inetintel/as_org.py
@@ -26,7 +26,7 @@ def get_latest_dataset_url(github_repo: str, data_dir: str, file_extension: str)
     latest_files = repo.get_contents(all_data_dir[-1])
     for file in latest_files:
         if file.path.endswith(file_extension):
-            print(file.download_url)
+            logging.info(file.download_url)
             return file.download_url
 
     return ''
@@ -79,12 +79,12 @@ class Crawler(BaseCrawler):
         with open(self.filename, 'w') as file:
             file.write(req.text)
 
-        print('Dataset crawled and saved in a temporary file.')
+        logging.info('Dataset crawled and saved in a temporary file.')
 
         # The dataset is very large. Pandas has the ability to read JSON, and, in
         # theory, it could do it in a more memory-efficient way.
         df = pd.read_json(self.filename, orient='index')
-        print('Dataset has {} rows.'.format(len(df)))
+        logging.info('Dataset has {} rows.'.format(len(df)))
 
         # Optimized code
         batch_size = 10000
@@ -176,8 +176,8 @@ class Crawler(BaseCrawler):
 
             count_rows_global += count_rows
             count_relationships_global += count_relationships
-            print('processed: {} rows and {} relationships'
-                  .format(count_rows_global, count_relationships_global))
+            logging.info('processed: {} rows and {} relationships'
+                         .format(count_rows_global, count_relationships_global))
 
     def close(self):
         super().close()

--- a/iyp/crawlers/manrs/members.py
+++ b/iyp/crawlers/manrs/members.py
@@ -99,9 +99,6 @@ class Crawler(BaseCrawler):
                     if action_bool == 'Yes':
                         implement_rel_set.add((asn, self.actions[j]['qid']))
 
-            print(f'\rProcessed {i} organizations', file=sys.stderr, end='')
-        print()
-
         # Get/create nodes.
         asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asn_set, all=False)
         country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', country_set)

--- a/iyp/crawlers/nro/delegated_stats.py
+++ b/iyp/crawlers/nro/delegated_stats.py
@@ -76,7 +76,7 @@ class Crawler(BaseCrawler):
         asn_status_links = defaultdict(list)
         prefix_status_links = defaultdict(list)
 
-        logging.info('Parsing file')
+        logging.info('Parsing file...')
         for line in req.text.splitlines():
             # Skip comments.
             if line.strip().startswith('#'):

--- a/iyp/crawlers/pch/show_bgp_parser.py
+++ b/iyp/crawlers/pch/show_bgp_parser.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import sys
 from collections import defaultdict, namedtuple
 from ipaddress import (AddressValueError, IPv4Address, IPv4Network,
                        IPv6Address, IPv6Network)
@@ -52,7 +51,6 @@ class ShowBGPParser:
         for c in code:
             if c not in self.status_codes:
                 logging.critical(f'{self.collector}: Invalid status code {c} in code {code}')
-                print(f'{self.collector}: Invalid status code {c} in code {code}', file=sys.stderr)
                 return set()
             ret.add(self.status_codes[c])
         return ret
@@ -61,7 +59,6 @@ class ShowBGPParser:
         """Map origin code to its label."""
         if code not in self.origin_codes:
             logging.critical(f'{self.collector}: Invalid origin code {code}')
-            print(f'{self.collector}: Invalid origin code {code}', file=sys.stderr)
             return str()
         return self.origin_codes[code]
 
@@ -178,10 +175,8 @@ class ShowBGPParser:
             prefix_map[prefix].add(origin)
         if not_valid_routes:
             logging.info(f'{self.collector}: Ignored {not_valid_routes} not valid routes.')
-            print(f'{self.collector}: Ignored {not_valid_routes} not valid routes.', file=sys.stderr)
         if as_sets:
-            logging.info(f'{self.collector}: Ignored {as_sets} AS set origins.')
-            print(f'{self.collector}: Ignored {as_sets} AS set origins.', file=sys.stderr)
+            logging.debug(f'{self.collector}: Ignored {as_sets} AS set origins.')
         if incomplete_origin_routes:
             logging.info(f'{self.collector}: Ignored {incomplete_origin_routes} routes with incomplete origin.')
         return prefix_map
@@ -201,7 +196,7 @@ class ShowBGPParser:
         fixture: Tuple of (collector_name, input_str)
         """
         collector_name, input_str = fixture
-        logging.info(collector_name)
+        logging.debug(collector_name)
         self.collector = collector_name
         return collector_name, self.parse(input_str)
 
@@ -216,7 +211,6 @@ class ShowBGPParser:
                 pass
         except StopIteration:
             logging.warning(f'{self.collector}: Empty file.')
-            print(f'{self.collector}: Empty file.', file=sys.stderr)
             return dict()
         routes = list()
         last_pfx = str()

--- a/iyp/crawlers/peeringdb/fac.py
+++ b/iyp/crawlers/peeringdb/fac.py
@@ -50,7 +50,7 @@ class Crawler(BaseCrawler):
     def run(self):
         """Fetch facilities information from PeeringDB and push to IYP."""
 
-        sys.stderr.write('Fetching PeeringDB data...\n')
+        logging.info('Fetching PeeringDB data...')
         req = self.requests.get(URL, headers=self.headers)
         if req.status_code != 200:
             logging.error('Error while fetching peeringDB data')
@@ -103,7 +103,6 @@ class Crawler(BaseCrawler):
             try:
                 flat_fac = dict(flatdict.FlatDict(fac))
             except Exception as e:
-                sys.stderr.write(f'Cannot flatten dictionary {fac}\n{e}\n')
                 logging.error(f'Cannot flatten dictionary {fac}\n{e}')
 
             facid_qid = self.facid_id[fac['id']]

--- a/iyp/crawlers/peeringdb/ix.py
+++ b/iyp/crawlers/peeringdb/ix.py
@@ -131,7 +131,6 @@ class Crawler(BaseCrawler):
         self.ixs = result['data']
 
         # Register IXPs
-        logging.warning('Pushing IXP info...')
         self.register_ixs()
         self.ix_id = self.iyp.batch_get_node_extid(IXID_LABEL)
 
@@ -149,7 +148,6 @@ class Crawler(BaseCrawler):
         for ixlan in ixlans:
             self.ixlans[ixlan['id']] = ixlan
 
-        logging.warning('Pushing IXP LAN and members...')
         self.register_ix_membership()
         self.iyp.commit()
 

--- a/iyp/crawlers/peeringdb/org.py
+++ b/iyp/crawlers/peeringdb/org.py
@@ -95,7 +95,6 @@ class Crawler(BaseCrawler):
             try:
                 flat_org = dict(flatdict.FlatDict(org))
             except Exception as e:
-                sys.stderr.write(f'Cannot flatten dictionary {org}\n{e}\n')
                 logging.error(f'Cannot flatten dictionary {org}\n{e}')
 
             orgid_qid = self.orgid_id[org['id']]

--- a/iyp/crawlers/ripe/as_names.py
+++ b/iyp/crawlers/ripe/as_names.py
@@ -36,7 +36,7 @@ class Crawler(BaseCrawler):
 
             # Country codes are two digits
             if len(cc) > 2:
-                print(cc)
+                logging.warning(cc)
                 continue
 
             asn = int(asn)

--- a/iyp/crawlers/ripe/atlas_probes.py
+++ b/iyp/crawlers/ripe/atlas_probes.py
@@ -52,12 +52,12 @@ class Crawler(BaseCrawler):
 
         next_url = data['next']
         if not next_url:
-            logging.info('Reached end of list')
+            logging.debug('Reached end of list')
             next_url = str()
         return next_url, data['results']
 
     def __execute_query(self, url: str):
-        logging.info(f'Querying {url}')
+        logging.debug(f'Querying {url}')
         r = self.session.get(url)
         return self.__process_response(r)
 
@@ -75,8 +75,8 @@ class Crawler(BaseCrawler):
         while next_url:
             next_url, next_data = self.__execute_query(next_url)
             data += next_data
-            logging.info(f'Added {len(next_data)} probes. Total: {len(data)}')
-        print(f'Fetched {len(data)} probes.', file=sys.stderr)
+            logging.debug(f'Added {len(next_data)} probes. Total: {len(data)}')
+        logging.info(f'Fetched {len(data)} probes.')
 
         # Compute nodes
         probe_ids = set()
@@ -125,7 +125,6 @@ class Crawler(BaseCrawler):
                 probe.pop('country_code')
 
         # push nodes
-        logging.info('Fetching/pushing nodes')
         probe_id = dict()
         # Each probe is a JSON object with nested fields, so we need to flatten it.
         flattened_probes = [dict(flatdict.FlatterDict(probe, delimiter='_')) for probe in valid_probes]
@@ -170,7 +169,6 @@ class Crawler(BaseCrawler):
                                      'props': [self.reference]})
 
         # Push all links to IYP
-        logging.info('Fetching/pushing relationships')
         self.iyp.batch_add_links('ASSIGNED', assigned_links)
         self.iyp.batch_add_links('LOCATED_IN', located_in_links)
         self.iyp.batch_add_links('COUNTRY', country_links)
@@ -194,7 +192,7 @@ def main() -> None:
     )
 
     logging.info(f'Started: {sys.argv}')
-    print('Fetching RIPE Atlas probes', file=sys.stderr)
+    print('Fetching RIPE Atlas probes')
 
     crawler = Crawler(ORG, URL, NAME)
     if args.unit_test:

--- a/iyp/crawlers/tranco/top1m.py
+++ b/iyp/crawlers/tranco/top1m.py
@@ -36,7 +36,7 @@ class Crawler(BaseCrawler):
 
         self.tranco_qid = self.iyp.get_node('Ranking', {'name': 'Tranco top 1M'})
 
-        sys.stderr.write('Downloading latest list...\n')
+        logging.info('Downloading latest list...')
         req = requests.get(URL)
         if req.status_code != 200:
             raise RequestStatusError('Error while fetching Tranco csv file')

--- a/iyp/crawlers/virginiatech/rovista.py
+++ b/iyp/crawlers/virginiatech/rovista.py
@@ -55,7 +55,6 @@ class Crawler(BaseCrawler):
             if len(data) < batch_size:
                 break
 
-        logging.info('Pushing nodes to neo4j...')
         # get ASNs and prefixes IDs
         self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
         tag_id_not_valid = self.iyp.get_node('Tag', {'label': 'Not Validating RPKI ROV'})
@@ -71,7 +70,6 @@ class Crawler(BaseCrawler):
                 links.append({'src_id': asn_qid, 'dst_id': tag_id_not_valid,
                              'props': [self.reference, {'ratio': entry['ratio']}]})
 
-        logging.info('Pushing links to neo4j...')
         # Push all links to IYP
         self.iyp.batch_add_links('CATEGORIZED', links)
 

--- a/iyp/post/country_information.py
+++ b/iyp/post/country_information.py
@@ -17,7 +17,7 @@ class PostProcess(BasePostProcess):
 
         for country_code in country_id:
             if country_code not in iso3166.countries_by_alpha2:
-                logging.error(f'Country code {country_code} is not ISO 3166-1 alpha-2 conform.')
+                logging.error(f'Country code "{country_code}" is not ISO 3166-1 alpha-2 conform.')
                 continue
             country_info = iso3166.countries_by_alpha2[country_code]
             new_props = {'name': country_info.apolitical_name,

--- a/iyp/post/dns_hierarchy.py
+++ b/iyp/post/dns_hierarchy.py
@@ -18,12 +18,10 @@ class PostProcess(BasePostProcess):
         """
 
         self.reference['reference_name'] = 'iyp.post.dns_hierarchy'
-        print('Building DNS hierarchy.', file=sys.stderr)
+        logging.info('Building DNS hierarchy.')
 
         # Fetch all existing DomainName nodes.
         dns_id = self.iyp.batch_get_nodes_by_single_prop('DomainName', 'name')
-        logging.info(f'Fetched {len(dns_id):,d} DomainName nodes.')
-        print(f'Fetched {len(dns_id):,d} DomainName nodes.', file=sys.stderr)
 
         # Build hierarchical relationships and keep track of new nodes that have to be
         # created.
@@ -40,8 +38,6 @@ class PostProcess(BasePostProcess):
                 dns_name = parent
 
         # Create new nodes.
-        logging.info(f'Creating {len(new_nodes):,d} new DomainName nodes.')
-        print(f'Creating {len(new_nodes):,d} new DomainName nodes.', file=sys.stderr)
         dns_id.update(self.iyp.batch_get_nodes_by_single_prop('DomainName', 'name', new_nodes, all=False))
 
         # Build relationships and push to IYP.
@@ -49,8 +45,6 @@ class PostProcess(BasePostProcess):
         for child, parent in link_tuples:
             part_of_links.append({'src_id': dns_id[child], 'dst_id': dns_id[parent], 'props': [self.reference]})
 
-        logging.info(f'Creating {len(part_of_links):,d} PART_OF relationships.')
-        print(f'Creating {len(part_of_links):,d} PART_OF relationships.', file=sys.stderr)
         self.iyp.batch_add_links('PART_OF', part_of_links)
 
     def count_relation(self):


### PR DESCRIPTION
All crawlers now log only using the logging module and not using stderr anymore. Also the IYP module now automatically logs node/relationship retrieval and creation. As a consequence, some crawlers are a bit chatty, which should be fixed in the future.

The general log level was changed to INFO and the level name is now included in the logs instead of the process name.

As parts of this also some crawlers got reworked:

- alice_lg: Fixed unit test that checked for relationship types which are not created.
- ihr:
  - Reference modification time is more precise, matching the exact timebin used
  - Data is handled in-memory, removing need for temporary files
  - Moved to batch creation, making the crawler faster and removing dependency on other crawlers