### PR TITLE
fixed the deprecated keywords in the neo4j queries

### DIFF
--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -268,7 +268,8 @@ class IYP(object):
 
         if all:
             logging.info(f'Fetching all {label_str} nodes.')
-            existing_nodes = self.tx.run(f'MATCH (n:{label_str}) RETURN n.{prop_name} AS {prop_name}, elementId(n) AS _id')
+            existing_nodes = self.tx.run(f'MATCH (n:{label_str}) RETURN n.{
+                                         prop_name} AS {prop_name}, elementId(n) AS _id')
         else:
             logging.info(f'Fetching up to {len(prop_set)} {label_str} nodes.')
             list_prop = list(prop_set)
@@ -635,7 +636,7 @@ class BasePostProcess(object):
             'reference_org': 'Internet Yellow Pages',
             'reference_url_data': 'https://iyp.iijlab.net',
             'reference_url_info': str(),
-            'reference_time_fetch': datetime.combine(datetime.utcnow(), time.min, timezone.utc),
+            'reference_time_fetch': datetime.combine(datetime.now(timezone.utc), time.min, timezone.utc),
             'reference_time_modification': None
         }
 
@@ -663,7 +664,7 @@ class BaseCrawler(object):
             'reference_org': organization,
             'reference_url_data': url,
             'reference_url_info': str(),
-            'reference_time_fetch': datetime.combine(datetime.utcnow(), time.min, timezone.utc),
+            'reference_time_fetch': datetime.combine(datetime.now(timezone.utc), time.min, timezone.utc),
             'reference_time_modification': None
         }
 

--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -54,7 +54,7 @@ def batch_format_link_properties(links: list, inplace=True) -> Optional[list]:
                 link['props'][idx] = format_properties(prop_dict)
         return None
     return [{'src_id': link['src_id'],
-             'dst_id': link['dst_id'],
+            'dst_id': link['dst_id'],
              'props': [format_properties(d) for d in link['props']]}
             for link in links]
 
@@ -99,8 +99,7 @@ def set_modification_time_from_last_modified_header(reference, response):
         last_modified_str = response.headers['Last-Modified']
         # All HTTP dates are in UTC:
         # https://www.rfc-editor.org/rfc/rfc2616#section-3.3.1
-        last_modified = datetime.strptime(last_modified_str,
-                                          '%a, %d %b %Y %H:%M:%S %Z').replace(tzinfo=timezone.utc)
+        last_modified = datetime.strptime(last_modified_str, '%a, %d %b %Y %H:%M:%S %Z').replace(tzinfo=timezone.utc)
         reference['reference_time_modification'] = last_modified
     except KeyError:
         logging.warning('No Last-Modified header; will not set modification time.')

--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -269,7 +269,8 @@ class IYP(object):
 
         if all:
             logging.info(f'Fetching all {label_str} nodes.')
-            existing_nodes = self.tx.run(f'MATCH (n:{label_str}) RETURN n.{prop_name} AS {prop_name}, ID(n) AS _id')
+            existing_nodes = self.tx.run(f'MATCH (n:{label_str}) RETURN n.{
+                                         prop_name} AS {prop_name}, elementId(n) AS _id')
         else:
             logging.info(f'Fetching up to {len(prop_set)} {label_str} nodes.')
             list_prop = list(prop_set)
@@ -277,7 +278,7 @@ class IYP(object):
             WITH $list_prop AS list_prop
             MATCH (n:{label_str})
             WHERE n.{prop_name} IN list_prop
-            RETURN n.{prop_name} AS {prop_name}, ID(n) AS _id""", list_prop=list_prop)
+            RETURN n.{prop_name} AS {prop_name}, elementId(n) AS _id""", list_prop=list_prop)
 
         ids = {node[prop_name]: node['_id'] for node in existing_nodes}
         existing_nodes_set = set(ids.keys())
@@ -292,7 +293,7 @@ class IYP(object):
 
                 create_query = f"""WITH $batch AS batch
                 UNWIND batch AS item CREATE (n:{label_str})
-                SET n = item RETURN n.{prop_name} AS {prop_name}, ID(n) AS _id"""
+                SET n = item RETURN n.{prop_name} AS {prop_name}, elementId(n) AS _id"""
 
                 new_nodes = self.tx.run(create_query, batch=batch)
 
@@ -405,7 +406,7 @@ class IYP(object):
         query = f"""UNWIND $props AS prop
                     {action} (a:{label_str} {where_clause_str})
                     {set_line}
-                    RETURN {return_clause_str}, ID(a) AS _id"""
+                    RETURN {return_clause_str}, elementId(a) AS _id"""
 
         ids = dict()
         for i in range(0, len(properties), BATCH_SIZE):
@@ -461,11 +462,11 @@ class IYP(object):
             result = self.tx.run(
                 f"""MERGE (a:{label} {dict2str(id_property_dict)})
                 SET a += {dict2str(properties)}
-                RETURN ID(a)"""
+                RETURN elementId(a)"""
             ).single()
         else:
             # MATCH node
-            result = self.tx.run(f'MATCH (a:{label_str} {dict2str(properties)}) RETURN ID(a)').single()
+            result = self.tx.run(f'MATCH (a:{label_str} {dict2str(properties)}) RETURN elementId(a)').single()
 
         if result is not None:
             return result[0]
@@ -489,7 +490,7 @@ class IYP(object):
 
             self.tx.run(f"""WITH $batch AS batch
                         MATCH (n)
-                        WHERE ID(n) IN batch
+                        WHERE elementId(n) IN batch
                         SET n:{label_str}""",
                         batch=batch)
             self.commit()
@@ -501,7 +502,7 @@ class IYP(object):
         Return None if the node does not exist.
         """
 
-        result = self.tx.run(f'MATCH (a)-[:EXTERNAL_ID]->(i:{id_type}) RETURN i.id AS extid, ID(a) AS nodeid')
+        result = self.tx.run(f'MATCH (a)-[:EXTERNAL_ID]->(i:{id_type}) RETURN i.id AS extid, elementId(a) AS nodeid')
 
         ids = {}
         for node in result:
@@ -516,7 +517,7 @@ class IYP(object):
         Return None if the node does not exist.
         """
 
-        result = self.tx.run(f'MATCH (a)-[:EXTERNAL_ID]->(:{id_type} {{id:{id}}}) RETURN ID(a)').single()
+        result = self.tx.run(f'MATCH (a)-[:EXTERNAL_ID]->(:{id_type} {{id:{id}}}) RETURN elementId(a)').single()
 
         if result is not None:
             return result[0]
@@ -547,7 +548,7 @@ class IYP(object):
             create_query = f"""WITH $batch AS batch
             UNWIND batch AS link
                 MATCH (x), (y)
-                WHERE ID(x) = link.src_id AND ID(y) = link.dst_id
+                WHERE ID(x) = link.src_id AND elementId(y) = link.dst_id
                 CREATE (x)-[l:{type}]->(y)
                 WITH l, link
                 UNWIND link.props AS prop
@@ -557,7 +558,7 @@ class IYP(object):
                 create_query = f"""WITH $batch AS batch
                 UNWIND batch AS link
                     MATCH (x), (y)
-                    WHERE ID(x) = link.src_id AND ID(y) = link.dst_id
+                    WHERE ID(x) = link.src_id AND elementId(y) = link.dst_id
                     MERGE (x)-[l:{type}]-(y)
                     WITH l,  link
                     UNWIND link.props AS prop
@@ -619,7 +620,7 @@ class IYP(object):
             add_query = """WITH $batch AS batch
             UNWIND batch AS item
             MATCH (n)
-            WHERE ID(n) = item.id
+            WHERE elementId(n) = item.id
             SET n += item.props"""
 
             res = self.tx.run(add_query, batch=batch)

--- a/iyp/__init__.py
+++ b/iyp/__init__.py
@@ -268,8 +268,7 @@ class IYP(object):
 
         if all:
             logging.info(f'Fetching all {label_str} nodes.')
-            existing_nodes = self.tx.run(f'MATCH (n:{label_str}) RETURN n.{
-                                         prop_name} AS {prop_name}, elementId(n) AS _id')
+            existing_nodes = self.tx.run(f'MATCH (n:{label_str}) RETURN n.{prop_name} AS {prop_name}, elementId(n) AS _id')
         else:
             logging.info(f'Fetching up to {len(prop_set)} {label_str} nodes.')
             list_prop = list(prop_set)


### PR DESCRIPTION
@m-appel check this out i have made the asked changes...
closes #154 
<!--- Provide a general summary of your changes in the Title above -->

## Description
id() changed with elementId() in neo4j with new required documentation [elementId()](https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-elementid)
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
pre-commit checks 

## Screenshots (if appropriate):
<img width="1710" alt="Screenshot 2024-12-03 at 5 28 41 PM" src="https://github.com/user-attachments/assets/fe21db0e-4b7f-4a39-af90-e7561af1053d">
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

