### PR TITLE
Add crawler for Google's CrUX top 1M per country

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -84,6 +84,14 @@ This data is licensed under [CC BY-NC
 We use [AS names](https://github.com/emileaben/asnames) provided by Emile Aben and
 others with permission (Hi Emile!).
 
+## Google
+
+We use [Crux's](https://developer.chrome.com/docs/crux) top 1M websites per country
+from Google.
+
+This data is licensed under  [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+No changes were made to the data.
+
 ## Internet Health Report
 
 We use three datasets from the [Internet Health Report](https://ihr.iijlab.net/) (that's

--- a/config.json.example
+++ b/config.json.example
@@ -92,6 +92,7 @@
             "iyp.crawlers.alice_lg.netnod",
             "iyp.crawlers.worldbank.country_pop",
             "iyp.crawlers.simulamet.rirdata_rdns",
+            "iyp.crawlers.google.crux_top1m_country",
             "iyp.crawlers.openintel.dnsgraph_nl",
             "iyp.crawlers.openintel.dnsgraph_rdns",
             "iyp.crawlers.cloudflare.dns_top_locations",

--- a/documentation/data-sources.md
+++ b/documentation/data-sources.md
@@ -23,6 +23,7 @@
 | Citizen Lab                 | URL testing lists                            | https://github.com/citizenlab/test-lists                        |
 | Cloudflare                  | Cloudflare Radar API endpoints radar/dns/top/ases, radar/dns/top/locations, radar/ranking/top, radar/datasets   | https://radar.cloudflare.com                                   |
 | Emile Aben                  | AS names                                     | https://github.com/emileaben/asnames                                 |
+| Google                      | CrUX top 1M websites per country             |  https://developer.chrome.com/docs/crux |
 | IHR                         | Country Dependency, AS Hegemony, ROV         | https://ihr.iijlab.net                                               |
 | Internet Intelligence Lab   | AS to Organization Mapping                   | https://github.com/InetIntel/Dataset-AS-to-Organization-Mapping      |
 | NRO                         | Extended allocation and assignment reports   | https://www.nro.net/about/rirs/statistics                            |

--- a/iyp/crawlers/google/README.md
+++ b/iyp/crawlers/google/README.md
@@ -1,18 +1,18 @@
-# Google CrUX
+# Google CrUX -- https://developer.chrome.com/docs/crux
 
 The Chrome User Experience Report (CrUX for short) is a dataset collected by
-Google that reflects how real-world Chrome users experience popular 
+Google that reflects how real-world Chrome users experience popular
 destinations on the web.
 
-CrUX data is collected from real browsers around the world, based on certain 
-browser options which determine user eligibility. A set of dimensions and metrics 
+CrUX data is collected from real browsers around the world, based on certain
+browser options which determine user eligibility. A set of dimensions and metrics
 are collected which allow site owners to determine how users experience their sites.
 
 IYP fetches CrUX's [top 1M popular websites per country](https://github.com/InternetHealthReport/crux-top-lists-country).
-Unlike others, CrUX rankings are buketed by rank magnitude order, not by
-specific rank. For example, rank are 1000, 10k, 100k, or 1M.
+Unlike others, CrUX rankings are bucketed by rank magnitude order, not by
+specific rank. For example, ranks are 1000, 10k, 100k, or 1M.
 
-In addition, CrUX ranks *origins* (e.g. https://www.google.com), not domain
+In addition, CrUX ranks *origins* (e.g., https://www.google.com), not domain
 or host names. In IYP we extract the hostname part of the origin and model this
 dataset using the hostname.
 

--- a/iyp/crawlers/google/README.md
+++ b/iyp/crawlers/google/README.md
@@ -19,7 +19,7 @@ dataset using the hostname.
 ## Graph representation
 
 ```cypher
-(:HostName {name:'www.iij.ad.jp'})-[:RANK {rank: 50000, origin:'https://www.iij.ad.jp'}]-(r:Ranking {name:'CrUX top 1M (JP)'})
+(:HostName {name:'www.iij.ad.jp'})-[:RANK {rank: 50000, origin:'https://www.iij.ad.jp'}]-(r:Ranking {name:'CrUX top 1M (JP)'})-[:COUNTRY]-(:Country {country_code:'JP'})
 ```
 
 The `RANK` relationship contains the property `origin` to recover the origin

--- a/iyp/crawlers/google/README.md
+++ b/iyp/crawlers/google/README.md
@@ -1,0 +1,30 @@
+# Google CrUX
+
+The Chrome User Experience Report (CrUX for short) is a dataset collected by
+Google that reflects how real-world Chrome users experience popular 
+destinations on the web.
+
+CrUX data is collected from real browsers around the world, based on certain 
+browser options which determine user eligibility. A set of dimensions and metrics 
+are collected which allow site owners to determine how users experience their sites.
+
+IYP fetches CrUX's [top 1M popular websites per country](https://github.com/InternetHealthReport/crux-top-lists-country).
+Unlike others, CrUX rankings are buketed by rank magnitude order, not by
+specific rank. For example, rank are 1000, 10k, 100k, or 1M.
+
+In addition, CrUX ranks *origins* (e.g. https://www.google.com), not domain
+or host names. In IYP we extract the hostname part of the origin and model this
+dataset using the hostname.
+
+## Graph representation
+
+```cypher
+(:HostName {name:'www.iij.ad.jp'})-[:RANK {rank: 50000, origin:'https://www.iij.ad.jp'}]-(r:Ranking {name:'CrUX top 1M (JP)'})
+```
+
+The `RANK` relationship contains the property `origin` to recover the origin
+given in the original dataset.
+
+## Dependence
+
+This crawler is not depending on other crawlers.

--- a/iyp/crawlers/google/crux_top1m_country.py
+++ b/iyp/crawlers/google/crux_top1m_country.py
@@ -2,24 +2,22 @@ import argparse
 import logging
 import os
 import sys
-from datetime import timezone
 from urllib.error import HTTPError
 
 import arrow
+import iso3166
 import pandas as pd
-from iso3166 import countries
 
 from iyp import BaseCrawler
 
 # Data source Google (archived on github by IHR)
 ORG = 'Google'
-URL = 'https://github.com/InternetHealthReport/crux-top-lists-country/main/data/country/'
+URL = 'https://github.com/InternetHealthReport/crux-top-lists-country/raw/refs/heads/main/data/country'
 NAME = 'google.crux_top1m_country'
 
 
 def generate_url(country_code, date):
-    base_url = 'https://github.com/InternetHealthReport/crux-top-lists-country/raw/refs/heads/main/data/country/'
-    joined_url = os.path.join(base_url, country_code.lower(), f'{date.year}{date.month:02d}.csv.gz')
+    joined_url = os.path.join(URL, country_code.lower(), f'{date.year}{date.month:02d}.csv.gz')
     return joined_url
 
 
@@ -31,59 +29,86 @@ class Crawler(BaseCrawler):
     def run(self):
         """Fetch data and push to IYP."""
 
-        for country in countries:
+        rankings = set()
+        hostnames = set()
+        countries = set()
+
+        country_links = list()
+        rank_links = list()
+        for country in iso3166.countries:
             country_code = country.alpha2
 
-            start = arrow.now().shift(months=-3)
-            end = arrow.now()
+            end = arrow.utcnow().replace(day=1, hour=0, minute=0, microsecond=0)
+            start = end.shift(months=-3)
             df = None
 
             for date in reversed(list(arrow.Arrow.range('month', start, end))):
                 # Fetch data
                 try:
-                    df = pd.read_csv(generate_url(country_code, date))
+                    url = generate_url(country_code, date)
+                    df = pd.read_csv(url)
 
                     # Set the modification time to the time of the dump
-                    self.reference['reference_time_modification'] = date.replace(tzinfo=timezone.utc)
-
+                    self.reference['reference_time_modification'] = date.datetime
+                    self.reference['reference_url_data'] = url
+                    break
                 except HTTPError:
+                    # Data not available for this timestamp.
                     continue
 
             if df is None:
-                # this country is not in the dataset
+                # This country is not in the dataset or no data available within the
+                # timeframe.
                 continue
 
             # Extract hostname from "URLs"
             df['hostname'] = df['origin'].str.partition('://')[2]
 
+            ranking_name = f'CrUX top 1M ({country_code})'
+
             # Create/fetch corresponding nodes in IYP
-            nodes = set(df['hostname'].unique())
-            node_id = self.iyp.batch_get_nodes_by_single_prop('HostName', 'name', nodes, all=False)
-            ranking = self.iyp.get_node('Ranking', {'name': f'CrUX top 1M ({country_code})'})
-            country = self.iyp.get_node('Country', {'country_code': country_code}, ['country_code'])
+            hostnames.update(df['hostname'].unique())
+            rankings.add(ranking_name)
+            countries.add(country_code)
 
-            # Create the (:Ranking)-[:COUNTRY]-(:Country) relationship
-            self.iyp.add_links(ranking, [['COUNTRY', country, self.reference]])
+            country_links.append({
+                'src_id': ranking_name,
+                'dst_id': country_code,
+                'props': [
+                    self.reference.copy()
+                ]
+            })
 
-            # Compute hostname/ranking relationships
-            links = list()
-
-            for _, row in df.iterrows():
-                links.append({
-                    'src_id': node_id[row['hostname']],
-                    'dst_id': ranking,
+            for row in df.itertuples():
+                rank_links.append({
+                    'src_id': row.hostname,
+                    'dst_id': ranking_name,
                     'props': [
-                        self.reference,
-                        {'rank': row['rank'], 'origin': row['origin']}
+                        self.reference.copy(),
+                        {'rank': row.rank, 'origin': row.origin, 'country_code': country_code}
                     ]
                 })
 
-            # Create the (:HostName)-[:RANK]-(:Ranking) relationship
-            self.iyp.batch_add_links('RANK', links)
+        ranking_id = self.iyp.batch_get_nodes_by_single_prop('Ranking', 'name', rankings, all=False)
+        hostname_id = self.iyp.batch_get_nodes_by_single_prop('HostName', 'name', hostnames, all=False)
+        country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries, all=False)
+
+        for link in country_links:
+            link['src_id'] = ranking_id[link['src_id']]
+            link['dst_id'] = country_id[link['dst_id']]
+
+        for link in rank_links:
+            link['src_id'] = hostname_id[link['src_id']]
+            link['dst_id'] = ranking_id[link['dst_id']]
+
+        # Create the (:Ranking)-[:COUNTRY]-(:Country) relationship
+        self.iyp.batch_add_links('COUNTRY', country_links)
+        # Create the (:HostName)-[:RANK]-(:Ranking) relationship
+        self.iyp.batch_add_links('RANK', rank_links)
 
     def unit_test(self):
         # Unit test checks for existence of relationships created by this crawler.
-        return super().unit_test(['RANK'])
+        return super().unit_test(['COUNTRY', 'RANK'])
 
 
 def main() -> None:
@@ -96,7 +121,7 @@ def main() -> None:
     logging.basicConfig(
         format=FORMAT,
         filename='log/' + scriptname + '.log',
-        level=logging.WARNING,
+        level=logging.INFO,
         datefmt='%Y-%m-%d %H:%M:%S'
     )
 

--- a/iyp/crawlers/google/crux_top1m_country.py
+++ b/iyp/crawlers/google/crux_top1m_country.py
@@ -1,0 +1,116 @@
+import argparse
+import logging
+import os
+import sys
+from datetime import timezone
+from urllib.error import HTTPError
+
+import arrow
+import pandas as pd
+from iso3166 import countries
+
+from iyp import BaseCrawler
+
+# Data source Google (archived on github by IHR)
+ORG = 'Google'
+URL = 'https://github.com/InternetHealthReport/crux-top-lists-country/main/data/country/'
+NAME = 'google.crux_top1m_country'
+
+
+def generate_url(country_code, date):
+    base_url = 'https://github.com/InternetHealthReport/crux-top-lists-country/raw/refs/heads/main/data/country/'
+    joined_url = os.path.join(base_url, country_code.lower(), f'{date.year}{date.month:02d}.csv.gz')
+    return joined_url
+
+
+class Crawler(BaseCrawler):
+    def __init__(self, organization, url, name):
+        super().__init__(organization, url, name)
+        self.reference['reference_url_info'] = 'https://developer.chrome.com/docs/crux/methodology'
+
+    def run(self):
+        """Fetch data and push to IYP."""
+
+        for country in countries:
+            country_code = country.alpha2
+
+            start = arrow.now().shift(months=-3)
+            end = arrow.now()
+            df = None
+
+            for date in reversed(list(arrow.Arrow.range('month', start, end))):
+                # Fetch data
+                try:
+                    df = pd.read_csv(generate_url(country_code, date))
+
+                    # Set the modification time to the time of the dump
+                    self.reference['reference_time_modification'] = date.replace(tzinfo=timezone.utc)
+
+                except HTTPError:
+                    continue
+
+            if df is None:
+                # this country is not in the dataset
+                continue
+
+            # Extract hostname from "URLs"
+            df['hostname'] = df['origin'].str.partition('://')[2]
+
+            # Create/fetch corresponding nodes in IYP
+            nodes = set(df['hostname'].unique())
+            node_id = self.iyp.batch_get_nodes_by_single_prop('HostName', 'name', nodes, all=False)
+            ranking = self.iyp.get_node('Ranking', {'name': f'CrUX top 1M ({country_code})'})
+            country = self.iyp.get_node('Country', {'country_code': country_code}, ['country_code'])
+
+            # Create the (:Ranking)-[:COUNTRY]-(:Country) relationship
+            self.iyp.add_links(ranking, [['COUNTRY', country, self.reference]])
+
+            # Compute hostname/ranking relationships
+            links = list()
+
+            for _, row in df.iterrows():
+                links.append({
+                    'src_id': node_id[row['hostname']],
+                    'dst_id': ranking,
+                    'props': [
+                        self.reference,
+                        {'rank': row['rank'], 'origin': row['origin']}
+                    ]
+                })
+
+            # Create the (:HostName)-[:RANK]-(:Ranking) relationship
+            self.iyp.batch_add_links('RANK', links)
+
+    def unit_test(self):
+        # Unit test checks for existence of relationships created by this crawler.
+        return super().unit_test(['RANK'])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--unit-test', action='store_true')
+    args = parser.parse_args()
+
+    scriptname = os.path.basename(sys.argv[0]).replace('/', '_')[0:-3]
+    FORMAT = '%(asctime)s %(levelname)s %(message)s'
+    logging.basicConfig(
+        format=FORMAT,
+        filename='log/' + scriptname + '.log',
+        level=logging.WARNING,
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+    logging.info(f'Started: {sys.argv}')
+
+    crawler = Crawler(ORG, URL, NAME)
+    if args.unit_test:
+        crawler.unit_test()
+    else:
+        crawler.run()
+        crawler.close()
+    logging.info(f'Finished: {sys.argv}')
+
+
+if __name__ == '__main__':
+    main()
+    sys.exit(0)

--- a/iyp/crawlers/google/crux_top1m_country.py
+++ b/iyp/crawlers/google/crux_top1m_country.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from iyp import BaseCrawler
 
-# Data source Google (archived on github by IHR)
+# Data source Google (archived on GitHub by IHR)
 ORG = 'Google'
 URL = 'https://github.com/InternetHealthReport/crux-top-lists-country/raw/refs/heads/main/data/country'
 NAME = 'google.crux_top1m_country'
@@ -35,11 +35,13 @@ class Crawler(BaseCrawler):
 
         country_links = list()
         rank_links = list()
+
+        end = arrow.utcnow().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        start = end.shift(months=-3)
+
         for country in iso3166.countries:
             country_code = country.alpha2
 
-            end = arrow.utcnow().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-            start = end.shift(months=-3)
             df = None
 
             for date in reversed(list(arrow.Arrow.range('month', start, end))):
@@ -66,7 +68,6 @@ class Crawler(BaseCrawler):
 
             ranking_name = f'CrUX top 1M ({country_code})'
 
-            # Create/fetch corresponding nodes in IYP
             hostnames.update(df['hostname'].unique())
             rankings.add(ranking_name)
             countries.add(country_code)
@@ -89,10 +90,12 @@ class Crawler(BaseCrawler):
                     ]
                 })
 
+        # Create/fetch corresponding nodes in IYP
         ranking_id = self.iyp.batch_get_nodes_by_single_prop('Ranking', 'name', rankings, all=False)
         hostname_id = self.iyp.batch_get_nodes_by_single_prop('HostName', 'name', hostnames, all=False)
         country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries, all=False)
 
+        # Replace link ends with QIDs
         for link in country_links:
             link['src_id'] = ranking_id[link['src_id']]
             link['dst_id'] = country_id[link['dst_id']]

--- a/iyp/crawlers/google/crux_top1m_country.py
+++ b/iyp/crawlers/google/crux_top1m_country.py
@@ -38,7 +38,7 @@ class Crawler(BaseCrawler):
         for country in iso3166.countries:
             country_code = country.alpha2
 
-            end = arrow.utcnow().replace(day=1, hour=0, minute=0, microsecond=0)
+            end = arrow.utcnow().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
             start = end.shift(months=-3)
             df = None
 


### PR DESCRIPTION
This adds Google's CrUX top 1M as discussed here: https://github.com/InternetHealthReport/internet-yellow-pages/discussions/153

Slightly different modeling, I just simplified the properties of the RANK relationship. It includes on the `rank` and `origin`.


## How Has This Been Tested?

Tested locally, it took over 1.5 hours to run. But after all this is a fairly big dataset containing 200+ 1M top lists.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

