### PR TITLE
Add more specific prefix node types

### DIFF
--- a/documentation/node-types.md
+++ b/documentation/node-types.md
@@ -8,6 +8,7 @@
 | AtlasProbe              | RIPE Atlas probe, uniquely identified with the **id** property.                                                                   |
 | AuthoritativeNameServer | Authoritative DNS nameserver for a set of domain names, uniquely identified with the **name** property.                           |
 | BGPCollector            | A RIPE RIS or RouteViews BGP collector, uniquely identified with the **name** property.                                           |
+| BGPPrefix               | An IP prefix announced in BGP, this is a subtype of Prefix.                                                                       |
 | CaidaIXID               | Unique identifier for IXPs from CAIDA's IXP dataset.                                                                              |
 | Country                 | Represent an economy, uniquely identified by either its two or three character code (properties **country_code** and **alpha3**). |
 | DomainName              | Any DNS domain name that is not a FQDN (see HostName), uniquely identified by the **name** property.                              |
@@ -23,9 +24,12 @@
 | PeeringdbIXID           | Unique identifier for an IXP as assigned by PeeringDB.                                                                            |
 | PeeringdbNetID          | Unique identifier for an AS as assigned by PeeringDB.                                                                             |
 | PeeringdbOrgID          | Unique identifier for an Organization as assigned by PeeringDB.                                                                   |
+| PeeringLAN              | An IP prefix used by an IXP for its peering LAN, this is a subtype of Prefix.                                                     |
 | Prefix                  | An IPv4 or IPv6 prefix uniquely identified by the **prefix** property. The **af** property (address family) provides the IP version of the prefix.|
-| Ranking                 | Represent a specific ranking of Internet resources (e.g. CAIDA's ASRank or Tranco ranking). The rank value for each resource is given by the RANK relationship.|
-| Resolver                | An additional label added to IP nodes if they are a DNS resolver. |
+| Ranking                 | Represent a specific ranking of Internet resources (e.g. CAIDA's ASRank or Tranco ranking). The rank value for each resource is given by the RANK relationship. |
+| Resolver                | An additional label added to IP nodes if they are a DNS resolver.                                                                                               |
+| RIRPrefix               | An IP prefix assigned by of the five RIRs' (delegated files), this is a subtype of Prefix.                                                                      |
+| RPKIPrefix              | An IP prefix registered in RPKI, this is a subtype of Prefix.                                                                                                   |
 | Tag                     | The output of a classification. A tag can be the result of a manual or automated classification. Uniquely identified by the **label** property.|
 | URL                     | The full URL for an Internet resource, uniquely identified by the **url** property.                                               |
 

--- a/iyp/crawlers/alice_lg/README.md
+++ b/iyp/crawlers/alice_lg/README.md
@@ -24,7 +24,7 @@ List of supported IXPs:
 ```Cypher
 (:AS {asn: 2497})-[:MEMBER_OF {address: '80.81.193.136', routeserver_id: 'rs1_fra_ipv4'}]->(:IXP {name: 'DE-CIX Frankfurt'})
 // Routes are not crawled by default
-(:AS {asn: 3333})-[:ORIGINATE {neighbor_id: 'pb_0280_as20562', routeserver_id: 'rs01-bcix-v4'}]->(:Prefix {prefix: '193.0.0.0/21'})
+(:AS {asn: 3333})-[:ORIGINATE {neighbor_id: 'pb_0280_as20562', routeserver_id: 'rs01-bcix-v4'}]->(:BGPPrefix {prefix: '193.0.0.0/21'})
 ```
 
 There is the possibility of multiple relationships between the same node. However, these
@@ -39,7 +39,7 @@ This crawler requires peering LAN information to map the neighbor IP to an IXP.
 Therefore, it should be run after crawlers that create
 
 ```Cypher
-(:Prefix)-[:MANAGED_BY]->(:IXP)
+(:PeeringLAN)-[:MANAGED_BY]->(:IXP)
 ```
 
 relationships:

--- a/iyp/crawlers/alice_lg/__init__.py
+++ b/iyp/crawlers/alice_lg/__init__.py
@@ -423,7 +423,7 @@ class Crawler(BaseCrawler):
         if prefixes:
             prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
             # Add the BGPPrefix label
-            self.iyp.batch_add_node_label(prefix_id, 'BGPPrefix')
+            self.iyp.batch_add_node_label(list(prefix_id.values()), 'BGPPrefix')
 
         # Translate raw values to QID.
         for relationship in member_of_rels:

--- a/iyp/crawlers/bgpkit/README.md
+++ b/iyp/crawlers/bgpkit/README.md
@@ -31,7 +31,7 @@ a route collector hence participating in the RIS or RouteViews projects.
 Connect AS nodes to prefix nodes representing the prefixes originated by an AS.
 For example:
 ```
-(:AS  {asn:2497})-[:ORIGINATE]-(:Prefix {prefix: '101.128.128.0/17'})
+(:AS  {asn:2497})-[:ORIGINATE]-(:BGPPrefix {prefix: '101.128.128.0/17'})
 ```
 
 ## Dependence

--- a/iyp/crawlers/bgpkit/pfx2asn.py
+++ b/iyp/crawlers/bgpkit/pfx2asn.py
@@ -46,7 +46,9 @@ class Crawler(BaseCrawler):
 
         # get ASNs and prefixes IDs
         self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
-        self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes)
+        self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
+        # Add the BGPPrefix label
+        self.iyp.batch_add_node_label(self.prefix_id, 'BGPPrefix')
 
         # Compute links
         links = []

--- a/iyp/crawlers/bgpkit/pfx2asn.py
+++ b/iyp/crawlers/bgpkit/pfx2asn.py
@@ -48,7 +48,7 @@ class Crawler(BaseCrawler):
         self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
         self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
         # Add the BGPPrefix label
-        self.iyp.batch_add_node_label(self.prefix_id, 'BGPPrefix')
+        self.iyp.batch_add_node_label(list(self.prefix_id.values()), 'BGPPrefix')
 
         # Compute links
         links = []

--- a/iyp/crawlers/bgptools/README.md
+++ b/iyp/crawlers/bgptools/README.md
@@ -25,7 +25,7 @@ given tag.
 ### Anycast IPv4 and IPv6 prefixes
 Connect Prefix to tag node meaning that an prefix has been categorized according to the TAG with a label `Anycast`.
 ```
-(:Prefix {prefix: '43.249.213.0/24'})-[:CATEGORIZED]-(:Tag {label: 'Anycast'})
+(:BGPPrefix {prefix: '43.249.213.0/24'})-[:CATEGORIZED]-(:Tag {label: 'Anycast'})
 ```
 
 ## Dependence

--- a/iyp/crawlers/bgptools/anycast_prefixes.py
+++ b/iyp/crawlers/bgptools/anycast_prefixes.py
@@ -90,6 +90,7 @@ class Crawler(BaseCrawler):
                 lines.append(prefix)
 
             prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
+            self.iyp.batch_add_node_label(prefix_id, 'BGPPrefix')
             tag_id = self.iyp.get_node('Tag', {'label': 'Anycast'})
 
             links = []

--- a/iyp/crawlers/bgptools/anycast_prefixes.py
+++ b/iyp/crawlers/bgptools/anycast_prefixes.py
@@ -90,7 +90,7 @@ class Crawler(BaseCrawler):
                 lines.append(prefix)
 
             prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-            self.iyp.batch_add_node_label(prefix_id, 'BGPPrefix')
+            self.iyp.batch_add_node_label(list(prefix_id.values()), 'BGPPrefix')
             tag_id = self.iyp.get_node('Tag', {'label': 'Anycast'})
 
             links = []

--- a/iyp/crawlers/caida/README.md
+++ b/iyp/crawlers/caida/README.md
@@ -48,7 +48,7 @@ Nodes:
 
 - `(:IXP {name})`: IXP node
 - `(:Name {name})`: Name of IXP
-- `(:Prefix {prefix})`: Prefix of IXP peering LAN
+- `(:PeeringLAN {prefix})`: Prefix of IXP peering LAN
 - `(:CaidaIXID {id})`: ID of the IXP assigned by CAIDA
 - `(:Country {country_code})`: Country code
 - `(:URL {url})`: Website of IXP
@@ -60,7 +60,7 @@ Relationships:
 (:IXP)-[:EXTERNAL_ID]->(:CaidaIXID)
 (:IXP)-[:NAME]->(:Name)
 (:IXP)-[:WEBSITE]->(:URL)
-(:Prefix)-[:MANAGED_BY]->(:IXP)
+(:PeeringLAN)-[:MANAGED_BY]->(:IXP)
 ```
 
 ### Dependence

--- a/iyp/crawlers/caida/ixs.py
+++ b/iyp/crawlers/caida/ixs.py
@@ -124,7 +124,8 @@ class Crawler(BaseCrawler):
         name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', names)
         country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
         url_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', urls)
-        prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes)
+        prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
+        self.iyp.batch_add_node_label(prefix_id, 'PeeringLAN')
 
         # Compute links and add them to neo4j
         caida_id_links = []

--- a/iyp/crawlers/caida/ixs.py
+++ b/iyp/crawlers/caida/ixs.py
@@ -125,7 +125,7 @@ class Crawler(BaseCrawler):
         country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
         url_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', urls)
         prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-        self.iyp.batch_add_node_label(prefix_id, 'PeeringLAN')
+        self.iyp.batch_add_node_label(list(prefix_id.values()), 'PeeringLAN')
 
         # Compute links and add them to neo4j
         caida_id_links = []

--- a/iyp/crawlers/ihr/README.md
+++ b/iyp/crawlers/ihr/README.md
@@ -52,10 +52,10 @@ Connect prefixes to their origin AS, their AS dependencies, their RPKI/IRR statu
 (provided by Maxmind).
 
 ```Cypher
-(:Prefix {prefix: '8.8.8.0/24'})<-[:ORIGINATE]-(:AS {asn: 15169})
-(:Prefix {prefix: '8.8.8.0/24'})-[:DEPENDS_ON]->(:AS {asn: 15169})
-(:Prefix {prefix: '8.8.8.0/24'})-[:CATEGORIZED]->(:Tag {label: 'RPKI Valid'})
-(:Prefix {prefix: '8.8.8.0/24'})-[:COUNTRY]->(:Country {country_code: 'US'})
+(:BGPPrefix {prefix: '8.8.8.0/24'})<-[:ORIGINATE]-(:AS {asn: 15169})
+(:BGPPrefix {prefix: '8.8.8.0/24'})-[:DEPENDS_ON]->(:AS {asn: 15169})
+(:BGPPrefix {prefix: '8.8.8.0/24'})-[:CATEGORIZED]->(:Tag {label: 'RPKI Valid'})
+(:BGPPrefix {prefix: '8.8.8.0/24'})-[:COUNTRY]->(:Country {country_code: 'US'})
 ```
 
 Tag labels (possibly) added by this crawler:

--- a/iyp/crawlers/ihr/rov.py
+++ b/iyp/crawlers/ihr/rov.py
@@ -136,6 +136,7 @@ class Crawler(BaseCrawler):
 
         asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
         prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
+        self.iyp.batch_add_node_label(prefix_id, 'BGPPrefix')
         tag_id = self.iyp.batch_get_nodes_by_single_prop('Tag', 'label', tags, all=False)
         country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
 

--- a/iyp/crawlers/ihr/rov.py
+++ b/iyp/crawlers/ihr/rov.py
@@ -136,7 +136,7 @@ class Crawler(BaseCrawler):
 
         asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
         prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-        self.iyp.batch_add_node_label(prefix_id, 'BGPPrefix')
+        self.iyp.batch_add_node_label(list(prefix_id.values()), 'BGPPrefix')
         tag_id = self.iyp.batch_get_nodes_by_single_prop('Tag', 'label', tags, all=False)
         country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
 

--- a/iyp/crawlers/nro/README.md
+++ b/iyp/crawlers/nro/README.md
@@ -24,10 +24,10 @@ IYP.
 (:AS {asn: 608})-[:RESERVED {registry: 'arin'}]->(:OpaqueID {id: 'arin'})
 (:AS {asn: 2497})-[:COUNTRY]->(:Country {country_code: 'JP'})
 
-(:Prefix {prefix: '2a03:1dc0::/27'})-[:AVAILABLE {registry: 'ripencc'}]->(:OpaqueID {id: 'ripencc'})
-(:Prefix {prefix: '202.0.65.0/24'})-[:ASSIGNED {registry: 'apnic'}]->(:OpaqueID {id: 'A91A7381'})
-(:Prefix {prefix: '196.20.32.0/19'})-[:RESERVED {registry: 'afrinic'}]->(:OpaqueID {id: 'afrinic'})
-(:Prefix {prefix: '196.20.32.0/19'})-[:COUNTRY]->(:Country {country_code: 'ZZ'})
+(:RIRPrefix {prefix: '2a03:1dc0::/27'})-[:AVAILABLE {registry: 'ripencc'}]->(:OpaqueID {id: 'ripencc'})
+(:RIRPrefix {prefix: '202.0.65.0/24'})-[:ASSIGNED {registry: 'apnic'}]->(:OpaqueID {id: 'A91A7381'})
+(:RIRPrefix {prefix: '196.20.32.0/19'})-[:RESERVED {registry: 'afrinic'}]->(:OpaqueID {id: 'afrinic'})
+(:RIRPrefix {prefix: '196.20.32.0/19'})-[:COUNTRY]->(:Country {country_code: 'ZZ'})
 ```
 
 The report also contains `allocated` records that would result in a `ALLOCATED` relationship.

--- a/iyp/crawlers/nro/delegated_stats.py
+++ b/iyp/crawlers/nro/delegated_stats.py
@@ -172,7 +172,7 @@ class Crawler(BaseCrawler):
         # Create all nodes
         opaqueid_id = self.iyp.batch_get_nodes_by_single_prop('OpaqueID', 'id', opaqueids, all=False)
         prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-        self.iyp.batch_add_node_label(prefix_id, 'RIRPrefix')
+        self.iyp.batch_add_node_label(list(prefix_id.values()), 'RIRPrefix')
         country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries, all=False)
 
         # Replace with QIDs

--- a/iyp/crawlers/nro/delegated_stats.py
+++ b/iyp/crawlers/nro/delegated_stats.py
@@ -172,6 +172,7 @@ class Crawler(BaseCrawler):
         # Create all nodes
         opaqueid_id = self.iyp.batch_get_nodes_by_single_prop('OpaqueID', 'id', opaqueids, all=False)
         prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
+        self.iyp.batch_add_node_label(prefix_id, 'RIRPrefix')
         country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries, all=False)
 
         # Replace with QIDs

--- a/iyp/crawlers/pch/README.md
+++ b/iyp/crawlers/pch/README.md
@@ -18,7 +18,7 @@ not be visible in route collectors from Route Views or RIPE RIS.
 ## Graph representation
 
 ```Cypher
-(:AS {asn: 2497})-[:ORIGINATE {count: 4}]->(:Prefix {prefix: '101.128.128.0/17'})
+(:AS {asn: 2497})-[:ORIGINATE {count: 4}]->(:BGPPrefix {prefix: '101.128.128.0/17'})
 
 ```
 
@@ -28,5 +28,5 @@ A detailed list of collector names is also available via the `seen_by_collectors
 
 ## Dependence
 
-This crawler may create new `Prefix` nodes that miss the `af` property, so the
+This crawler may create new `BGPPrefix` nodes that miss the `af` property, so the
 `iyp.post.address_family` postprocessing script should be run after this.

--- a/iyp/crawlers/pch/__init__.py
+++ b/iyp/crawlers/pch/__init__.py
@@ -296,7 +296,7 @@ class RoutingSnapshotCrawler(BaseCrawler):
         # Get/push nodes.
         as_ids = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', ases, all=False)
         prefix_ids = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-        self.iyp.batch_add_node_label(prefix_ids, 'BGPPrefix')
+        self.iyp.batch_add_node_label(list(prefix_ids.values()), 'BGPPrefix')
 
         # Push relationships.
         relationships = list()

--- a/iyp/crawlers/pch/__init__.py
+++ b/iyp/crawlers/pch/__init__.py
@@ -32,7 +32,7 @@ class RoutingSnapshotCrawler(BaseCrawler):
 
     Fetches the latest IPv4/IPv6 snapshots in parallel from the PCH website and converts
     them to prefix-AS maps in parallel. This data is used to populate
-    (:AS)-[:ORIGINATE]->(:Prefix) entries in the graph.
+    (:AS)-[:ORIGINATE]->(:BGPPrefix) entries in the graph.
 
     If there are no results for the current day for some collectors, the crawler tries
     to fetch older results, up to a maximum of 7 days (configured by self.MAX_LOOKBACK).
@@ -296,6 +296,7 @@ class RoutingSnapshotCrawler(BaseCrawler):
         # Get/push nodes.
         as_ids = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', ases, all=False)
         prefix_ids = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
+        self.iyp.batch_add_node_label(prefix_ids, 'BGPPrefix')
 
         # Push relationships.
         relationships = list()

--- a/iyp/crawlers/peeringdb/README.md
+++ b/iyp/crawlers/peeringdb/README.md
@@ -81,7 +81,7 @@ Nodes:
 - `(:Name {name})`: Names of IXPs and networks
 - `(:PeeringdbIXID {id})`: ID of the IXP
 - `(:PeeringdbNetID {id})`: ID of the network
-- `(:Prefix {prefix})`: Prefix of IXP peering LAN
+- `(:PeeringLAN {prefix})`: Prefix of IXP peering LAN
 - `(:URL {url})`: Websites of IXPs and networks
 
 Relationships:
@@ -101,7 +101,7 @@ Relationships:
 (:AS)-[:NAME]->(:Name)
 (:AS)-[:WEBSITE]->(:URL)
 
-(:Prefix)-[:MANAGED_BY]->(:IXP)
+(:PeeringLAN)-[:MANAGED_BY]->(:IXP)
 ```
 
 Raw data attached to relationships:
@@ -127,7 +127,7 @@ MATCH (iij)-[r2:MANAGED_BY]->(n2:Organization)
 MATCH (iij)-[r3:MEMBER_OF]->(ix:IXP {name: 'DE-CIX Frankfurt'})
 MATCH (iij)-[r4:NAME {reference_org: 'PeeringDB'}]->(n3:Name)
 MATCH (iij)-[r5:WEBSITE]->(n4:URL)
-MATCH (pfx:Prefix {af: 4})-[r6:MANAGED_BY]->(ix)
+MATCH (pfx:PeeringLAN {af: 4})-[r6:MANAGED_BY]->(ix)
 MATCH (ix)-[r7:COUNTRY]->(n5:Country)
 MATCH (ix)-[r8:EXTERNAL_ID]->(n6:PeeringdbIXID)
 MATCH (ix)-[r9:LOCATED_IN]->(n7:Facility {name: 'Global Switch Frankfurt'})

--- a/iyp/crawlers/peeringdb/ix.py
+++ b/iyp/crawlers/peeringdb/ix.py
@@ -228,7 +228,7 @@ class Crawler(BaseCrawler):
                         handle_social_media(network, net_website)
 
         self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-        self.iyp.batch_add_node_label(self.prefix_id, 'PeeringLAN')
+        self.iyp.batch_add_node_label(list(self.prefix_id.values()), 'PeeringLAN')
         self.name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', net_names)
         self.website_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', net_website)
         self.netid_id = self.iyp.batch_get_nodes_by_single_prop(NETID_LABEL, 'id', net_extid)

--- a/iyp/crawlers/peeringdb/ix.py
+++ b/iyp/crawlers/peeringdb/ix.py
@@ -227,8 +227,8 @@ class Crawler(BaseCrawler):
                             net_website.add(network['website'])
                         handle_social_media(network, net_website)
 
-        # TODO add the type PEERING_LAN? may break the unique constraint
-        self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes)
+        self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
+        self.iyp.batch_add_node_label(self.prefix_id, 'PeeringLAN')
         self.name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', net_names)
         self.website_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', net_website)
         self.netid_id = self.iyp.batch_get_nodes_by_single_prop(NETID_LABEL, 'id', net_extid)

--- a/iyp/crawlers/ripe/README.md
+++ b/iyp/crawlers/ripe/README.md
@@ -28,7 +28,7 @@ to extract ROA information. The max length specification of the ROA is added as 
 property on the relationship.
 
 ```Cypher
-(:AS {asn: 2497})-[:ROUTE_ORIGIN_AUTHORIZATION {maxLength: 18}]->(:Prefix {prefix: '49.239.64.0/18'})
+(:AS {asn: 2497})-[:ROUTE_ORIGIN_AUTHORIZATION {maxLength: 18}]->(:RPKIPrefix {prefix: '49.239.64.0/18'})
 ```
 
 ### Atlas Probes - `atlas_probes.py`

--- a/iyp/crawlers/ripe/roa.py
+++ b/iyp/crawlers/ripe/roa.py
@@ -79,7 +79,8 @@ class Crawler(BaseCrawler):
 
             # get ASNs and prefixes IDs
             asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
-            prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', set(prefix_info.keys()))
+            prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', set(prefix_info.keys()), all=False)
+            self.iyp.batch_add_node_label(prefix_id, 'RPKIPrefix')
 
             links = []
             for prefix, attributes in prefix_info.items():

--- a/iyp/crawlers/ripe/roa.py
+++ b/iyp/crawlers/ripe/roa.py
@@ -80,7 +80,7 @@ class Crawler(BaseCrawler):
             # get ASNs and prefixes IDs
             asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
             prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', set(prefix_info.keys()), all=False)
-            self.iyp.batch_add_node_label(prefix_id, 'RPKIPrefix')
+            self.iyp.batch_add_node_label(list(prefix_id.values()), 'RPKIPrefix')
 
             links = []
             for prefix, attributes in prefix_info.items():

--- a/iyp/crawlers/simulamet/README.md
+++ b/iyp/crawlers/simulamet/README.md
@@ -12,7 +12,7 @@ hierarchy but instead add a simple MANAGED_BY link.
 ## Graph representation
 
 ```cypher
-(:Prefix {prefix: '103.2.57.0/24'})-[:MANAGED_BY {source: 'APNIC', ttl: 172800}]->(:AuthoritativeNameServer {name: 'dns0.iij.ad.jp'})
+(:RDNSPrefix {prefix: '103.2.57.0/24'})-[:MANAGED_BY {source: 'APNIC', ttl: 172800}]->(:AuthoritativeNameServer {name: 'dns0.iij.ad.jp'})
 ```
 
 The `source` property indicates from which RIR the information was obtained, the `ttl`

--- a/iyp/crawlers/simulamet/rirdata_rdns.py
+++ b/iyp/crawlers/simulamet/rirdata_rdns.py
@@ -111,7 +111,7 @@ class Crawler(BaseCrawler):
         ns_id = self.iyp.batch_get_nodes_by_single_prop('HostName', 'name', ns_set, all=False)
         self.iyp.batch_add_node_label(list(ns_id.values()), 'AuthoritativeNameServer')
         prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefix_set, all=False)
-        self.iyp.batch_add_node_label(prefix_id, 'RDNSPrefix')
+        self.iyp.batch_add_node_label(list(prefix_id.values()), 'RDNSPrefix')
 
         logging.info('Computing relationship')
         links_managed_by = []

--- a/iyp/crawlers/simulamet/rirdata_rdns.py
+++ b/iyp/crawlers/simulamet/rirdata_rdns.py
@@ -111,6 +111,7 @@ class Crawler(BaseCrawler):
         ns_id = self.iyp.batch_get_nodes_by_single_prop('HostName', 'name', ns_set, all=False)
         self.iyp.batch_add_node_label(list(ns_id.values()), 'AuthoritativeNameServer')
         prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefix_set, all=False)
+        self.iyp.batch_add_node_label(prefix_id, 'RDNSPrefix')
 
         logging.info('Computing relationship')
         links_managed_by = []


### PR DESCRIPTION
## Description

This adds more specific node types for prefixes. So we can distinguish prefixes that are observed in BGP, delegated stats, RPKI, etc. It add the node types:
- 'PeeringLAN'
- 'RIRPrefix',
- 'RPKIPrefix'
- 'BGPPrefix'

It also changes the behavior of ip2prefix. Now an IP has a `PART_OF` relationship to each different kind of prefix type.

This closes #103 and #104 

## How Has This Been Tested?

Retested all modified crawlers locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

It shouldn't break anything in IYP but it will on the IHR website.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

