### PR TITLE
Introduce Point node label and add geolocation modelling to existing crawlers

### DIFF
--- a/documentation/node-types.md
+++ b/documentation/node-types.md
@@ -26,11 +26,12 @@
 | PeeringdbNetID          | Unique identifier for an AS as assigned by PeeringDB.                                                                             |
 | PeeringdbOrgID          | Unique identifier for an Organization as assigned by PeeringDB.                                                                   |
 | PeeringLAN              | An IP prefix used by an IXP for its peering LAN, this is a subtype of Prefix.                                                     |
+| Point                   | A point on the earth surface uniquely identified by the **position** property. The position is expressed in the World Geodesic System, WGS84 (x=longitude, y=latitude).                                                 |
 | Prefix                  | An IPv4 or IPv6 prefix uniquely identified by the **prefix** property. The **af** property (address family) provides the IP version of the prefix.|
 | Ranking                 | Represent a specific ranking of Internet resources (e.g. CAIDA's ASRank or Tranco ranking). The rank value for each resource is given by the RANK relationship. |
-| RDNSPrefix              | An IP prefix representing a reverse DNS zone that is managed by one or more authoritative name servers. This is a subtype of Prefix. |
 | Resolver                | An additional label added to IP nodes if they are a DNS resolver.                                                                                               |
 | RIRPrefix               | An IP prefix assigned by of the five RIRs' (delegated files), this is a subtype of Prefix.                                                                      |
 | RPKIPrefix              | An IP prefix registered in RPKI, this is a subtype of Prefix.                                                                                                   |
 | Tag                     | The output of a classification. A tag can be the result of a manual or automated classification. Uniquely identified by the **label** property.|
 | URL                     | The full URL for an Internet resource, uniquely identified by the **url** property.                                               |
+

--- a/iyp/crawlers/caida/asrank.py
+++ b/iyp/crawlers/caida/asrank.py
@@ -109,7 +109,7 @@ class Crawler(BaseCrawler):
             if asn['latitude'] and asn['longitude']:
                 position = WGS84Point((asn['longitude'], asn['latitude']))
                 located_in_links.append(
-                        {'src_id': asn_qid, 'dst_id': self.point_id[position], 'props': [self.reference]})
+                    {'src_id': asn_qid, 'dst_id': self.point_id[position], 'props': [self.reference]})
 
         # Push all links to IYP
         self.iyp.batch_add_links('NAME', name_links)

--- a/iyp/crawlers/peeringdb/fac.py
+++ b/iyp/crawlers/peeringdb/fac.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 import flatdict
 import iso3166
 import requests_cache
+from neo4j.spatial import WGS84Point
 
 from iyp import BaseCrawler
 from iyp.crawlers.peeringdb.ix import (handle_social_media,
@@ -65,6 +66,7 @@ class Crawler(BaseCrawler):
         names = set()
         websites = set()
         countries = set()
+        points = set()
         facids = set()
 
         for fac in facilities:
@@ -78,6 +80,10 @@ class Crawler(BaseCrawler):
             if fac['country'] in iso3166.countries_by_alpha2:
                 countries.add(fac['country'])
 
+            if fac['latitude'] and fac['longitude']:
+                position = WGS84Point((fac['longitude'], fac['latitude']))
+                points.add(position)
+
             handle_social_media(fac, websites)
 
         # push nodes
@@ -85,6 +91,7 @@ class Crawler(BaseCrawler):
         self.name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', names)
         self.website_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', websites)
         self.country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
+        self.point_id = self.iyp.batch_get_nodes_by_single_prop('Point', 'position', points)
         self.facid_id = self.iyp.batch_get_nodes_by_single_prop(FACID_LABEL, 'id', facids)
 
         # get organization nodes
@@ -94,6 +101,7 @@ class Crawler(BaseCrawler):
         name_links = []
         website_links = []
         country_links = []
+        point_links = []
         facid_links = []
         org_links = []
 
@@ -120,6 +128,11 @@ class Crawler(BaseCrawler):
                 country_qid = self.country_id[fac['country']]
                 country_links.append({'src_id': fac_qid, 'dst_id': country_qid, 'props': [self.reference]})
 
+            if fac['latitude'] and fac['longitude']:
+                position = WGS84Point((fac['longitude'], fac['latitude']))
+                point_qid = self.point_id[position]
+                point_links.append({'src_id': fac_qid, 'dst_id': point_qid, 'props': [self.reference]})
+
             org_qid = self.org_id[fac['org_id']]
             org_links.append({'src_id': fac_qid, 'dst_id': org_qid, 'props': [self.reference]})
 
@@ -127,11 +140,12 @@ class Crawler(BaseCrawler):
         self.iyp.batch_add_links('NAME', name_links)
         self.iyp.batch_add_links('WEBSITE', website_links)
         self.iyp.batch_add_links('COUNTRY', country_links)
+        self.iyp.batch_add_links('LOCATED_IN', point_links)
         self.iyp.batch_add_links('EXTERNAL_ID', facid_links)
         self.iyp.batch_add_links('MANAGED_BY', org_links)
 
     def unit_test(self):
-        return super().unit_test(['NAME', 'WEBSITE', 'COUNTRY', 'EXTERNAL_ID', 'MANAGED_BY'])
+        return super().unit_test(['NAME', 'WEBSITE', 'COUNTRY', 'EXTERNAL_ID', 'MANAGED_BY', 'LOCATED_IN'])
 
 
 def main() -> None:

--- a/iyp/crawlers/ripe/atlas_probes.py
+++ b/iyp/crawlers/ripe/atlas_probes.py
@@ -168,13 +168,13 @@ class Crawler(BaseCrawler):
             if asv4:
                 as_qid = as_id[asv4]
                 located_in_as_links.append(
-                        {'src_id': probe_qid, 'dst_id': as_qid, 'props': [self.reference, {'af': 4}]})
+                    {'src_id': probe_qid, 'dst_id': as_qid, 'props': [self.reference, {'af': 4}]})
 
             asv6 = probe['asn_v6']
             if asv6:
                 as_qid = as_id[asv6]
                 located_in_as_links.append(
-                        {'src_id': probe_qid, 'dst_id': as_qid, 'props': [self.reference, {'af': 6}]})
+                    {'src_id': probe_qid, 'dst_id': as_qid, 'props': [self.reference, {'af': 6}]})
 
             if ('country_code' in probe
                 and (country_code := probe['country_code'])
@@ -188,7 +188,7 @@ class Crawler(BaseCrawler):
                     position = WGS84Point((geo_coordinates[0], geo_coordinates[1]))
                     point_qid = point_id[position]
                     located_in_point_links.append(
-                            {'src_id': probe_qid, 'dst_id': point_qid, 'props': [self.reference]})
+                        {'src_id': probe_qid, 'dst_id': point_qid, 'props': [self.reference]})
 
         # Push all links to IYP
         self.iyp.batch_add_links('ASSIGNED', assigned_links)


### PR DESCRIPTION
## Description
Introduce a new node label, `Point`, to model geo coordinates. A `Point` has a unique property `position` that gives the coordinates in the World Geodetic System (WGS84).
This PR also adds geo-location modelling to ASRank, Atlas probes, PeeringDB facility and organization.

## Motivation and Context
As discussed in #158 this is the first step to model geo-coordinates in IYP.

## How Has This Been Tested?

Tested the four crawlers locally.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

