### PR TITLE
Prefix remodelling

### DIFF
--- a/documentation/gallery.md
+++ b/documentation/gallery.md
@@ -89,9 +89,8 @@ WHERE dn.name ENDS WITH '.jp'
     AND r.rank < 5000
     AND dn.name = hn.name
 MATCH q = (hn)-[:RESOLVES_TO {reference_name: 'openintel.tranco1m'}]->(:IP)
-    -[po:PART_OF]->(:Prefix)
+    -[:PART_OF]->(:BGPPrefix)
     <-[:ORIGINATE {reference_name: 'bgpkit.pfx2asn'}]-(:AS)
-WHERE 'BGPPrefix' in po.prefix_types
 RETURN q
 ```
 

--- a/documentation/node-types.md
+++ b/documentation/node-types.md
@@ -8,14 +8,14 @@
 | AtlasProbe              | RIPE Atlas probe, uniquely identified with the **id** property.                                                                   |
 | AuthoritativeNameServer | Authoritative DNS nameserver for a set of domain names, uniquely identified with the **name** property.                           |
 | BGPCollector            | A RIPE RIS or RouteViews BGP collector, uniquely identified with the **name** property.                                           |
-| BGPPrefix               | An IP prefix announced in BGP, this is a subtype of Prefix.                                                                       |
+| BGPPrefix               | An IP prefix announced in BGP, uniquely identified with the **prefix** property. This is a subtype of Prefix.                                                                       |
 | CaidaIXID               | Unique identifier for IXPs from CAIDA's IXP dataset.                                                                              |
 | CaidaOrgID              | Identifier for Organizations from CAIDA's AS to organization dataset.                                                             |
 | Country                 | Represent an economy, uniquely identified by either its two or three character code (properties **country_code** and **alpha3**). |
 | DomainName              | Any DNS domain name that is not a FQDN (see HostName), uniquely identified by the **name** property.                              |
 | Estimate                | Represent a report that approximate a quantity, for example the World Bank population estimate.                                   |
 | Facility                | Co-location facility for IXPs and ASes, uniquely identified by the **name** property.                                             |
-| GeoPrefix               | An IP prefix obtained from a geolocation data source. This is a subtype of Prefix.                                                |
+| GeoPrefix               | An IP prefix obtained from a geolocation data source, uniquely identified with the **prefix** property. This is a subtype of Prefix.                                                |
 | HostName                | A fully qualified domain name uniquely identified by the **name** property.                                                       |
 | IP                      | An IPv4 or IPv6 address uniquely identified by the **ip** property. The **af** property (address family) provides the IP version of the prefix.|
 | IXP                     | An Internet Exchange Point, loosely identified by the **name** property or using related IDs (see the EXTERNAL_ID relationship).  |
@@ -26,14 +26,14 @@
 | PeeringdbIXID           | Unique identifier for an IXP as assigned by PeeringDB.                                                                            |
 | PeeringdbNetID          | Unique identifier for an AS as assigned by PeeringDB.                                                                             |
 | PeeringdbOrgID          | Unique identifier for an Organization as assigned by PeeringDB.                                                                   |
-| PeeringLAN              | An IP prefix used by an IXP for its peering LAN, this is a subtype of Prefix.                                                     |
+| PeeringLAN              | An IP prefix used by an IXP for its peering LAN, uniquely identified with the **prefix** property. This is a subtype of Prefix.                                                     |
 | Point                   | A point on the earth surface uniquely identified by the **position** property. The position is expressed in the World Geodesic System, WGS84 (x=longitude, y=latitude).                                                 |
-| Prefix                  | An IPv4 or IPv6 prefix uniquely identified by the **prefix** property. The **af** property (address family) provides the IP version of the prefix.|
+| Prefix                  | Generic type for IP prefixes covering all other prefix types (e.g. BGPPrefix, PeeringLAN, GeoPrefix). The prefix property is **not** unique for Prefix nodes. The **af** property (address family) provides the IP version of the prefix.|
 | Ranking                 | Represent a specific ranking of Internet resources (e.g. CAIDA's ASRank or Tranco ranking). The rank value for each resource is given by the RANK relationship. |
 | Resolver                | An additional label added to IP nodes if they are a DNS resolver.                                                                                               |
-| RDNSPrefix              | An IP prefix representing a reverse DNS zone that is managed by one or more authoritative name servers. This is a subtype of Prefix. |
-| RIRPrefix               | An IP prefix assigned by of the five RIRs' (delegated files), this is a subtype of Prefix.                                                                      |
-| RPKIPrefix              | An IP prefix registered in RPKI, this is a subtype of Prefix.                                                                                                   |
+| RDNSPrefix              | An IP prefix representing a reverse DNS zone that is managed by one or more authoritative name servers and uniquely identified with the **prefix** property. This is a subtype of Prefix. |
+| RIRPrefix               | An IP prefix assigned by of the five RIRs' (delegated files), uniquely identified with the **prefix** property. This is a subtype of Prefix.                                                                      |
+| RPKIPrefix              | An IP prefix registered in RPKI, uniquely identified with the **prefix** property. This is a subtype of Prefix.                                                                                                   |
 | Tag                     | The output of a classification. A tag can be the result of a manual or automated classification. Uniquely identified by the **label** property.|
 | URL                     | The full URL for an Internet resource, uniquely identified by the **url** property.                                               |
 

--- a/iyp/crawlers/alice_lg/__init__.py
+++ b/iyp/crawlers/alice_lg/__init__.py
@@ -424,9 +424,9 @@ class Crawler(BaseCrawler):
         asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns, all=False)
         prefix_id = dict()
         if prefixes:
-            prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-            # Add the BGPPrefix label
-            self.iyp.batch_add_node_label(list(prefix_id.values()), 'BGPPrefix')
+            prefix_id = self.iyp.batch_get_nodes_by_single_prop('BGPPrefix', 'prefix', prefixes, all=False)
+            # Add the Prefix label
+            self.iyp.batch_add_node_label(list(prefix_id.values()), 'Prefix')
 
         # Translate raw values to QID.
         for relationship in member_of_rels:

--- a/iyp/crawlers/bgpkit/pfx2asn.py
+++ b/iyp/crawlers/bgpkit/pfx2asn.py
@@ -44,9 +44,9 @@ class Crawler(BaseCrawler):
 
         # get ASNs and prefixes IDs
         self.asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
-        self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-        # Add the BGPPrefix label
-        self.iyp.batch_add_node_label(list(self.prefix_id.values()), 'BGPPrefix')
+        self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('BGPPrefix', 'prefix', prefixes, all=False)
+        # Add the Prefix label
+        self.iyp.batch_add_node_label(list(self.prefix_id.values()), 'Prefix')
 
         # Compute links
         links = []

--- a/iyp/crawlers/bgptools/anycast_prefixes.py
+++ b/iyp/crawlers/bgptools/anycast_prefixes.py
@@ -82,8 +82,8 @@ class Crawler(BaseCrawler):
                 prefixes.add(prefix)
                 lines.append(prefix)
 
-            prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-            self.iyp.batch_add_node_label(list(prefix_id.values()), 'BGPPrefix')
+            prefix_id = self.iyp.batch_get_nodes_by_single_prop('BGPPrefix', 'prefix', prefixes, all=False)
+            self.iyp.batch_add_node_label(list(prefix_id.values()), 'Prefix')
             tag_id = self.iyp.get_node('Tag', {'label': 'Anycast'})
 
             links = []

--- a/iyp/crawlers/caida/ixs.py
+++ b/iyp/crawlers/caida/ixs.py
@@ -123,8 +123,8 @@ class Crawler(BaseCrawler):
         name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', names)
         country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
         url_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', urls)
-        prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-        self.iyp.batch_add_node_label(list(prefix_id.values()), 'PeeringLAN')
+        prefix_id = self.iyp.batch_get_nodes_by_single_prop('PeeringLAN', 'prefix', prefixes, all=False)
+        self.iyp.batch_add_node_label(list(prefix_id.values()), 'Prefix')
 
         # Compute links and add them to neo4j
         caida_id_links = []

--- a/iyp/crawlers/ihr/rov.py
+++ b/iyp/crawlers/ihr/rov.py
@@ -135,8 +135,8 @@ class Crawler(BaseCrawler):
             })
 
         asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
-        prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-        self.iyp.batch_add_node_label(list(prefix_id.values()), 'BGPPrefix')
+        prefix_id = self.iyp.batch_get_nodes_by_single_prop('BGPPrefix', 'prefix', prefixes, all=False)
+        self.iyp.batch_add_node_label(list(prefix_id.values()), 'Prefix')
         tag_id = self.iyp.batch_get_nodes_by_single_prop('Tag', 'label', tags, all=False)
         country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries)
 

--- a/iyp/crawlers/ipinfo/ip_country.py
+++ b/iyp/crawlers/ipinfo/ip_country.py
@@ -49,8 +49,8 @@ class Crawler(BaseCrawler):
                 links.append({'src_id': prefix, 'dst_id': country_code, 'props': [self.reference, doc]})
 
         country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries, all=False)
-        prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-        self.iyp.batch_add_node_label(list(prefix_id.values()), 'GeoPrefix')
+        prefix_id = self.iyp.batch_get_nodes_by_single_prop('GeoPrefix', 'prefix', prefixes, all=False)
+        self.iyp.batch_add_node_label(list(prefix_id.values()), 'Prefix')
 
         for link in links:
             link['src_id'] = prefix_id[link['src_id']]

--- a/iyp/crawlers/nro/delegated_stats.py
+++ b/iyp/crawlers/nro/delegated_stats.py
@@ -170,8 +170,8 @@ class Crawler(BaseCrawler):
 
         # Create all nodes
         opaqueid_id = self.iyp.batch_get_nodes_by_single_prop('OpaqueID', 'id', opaqueids, all=False)
-        prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-        self.iyp.batch_add_node_label(list(prefix_id.values()), 'RIRPrefix')
+        prefix_id = self.iyp.batch_get_nodes_by_single_prop('RIRPrefix', 'prefix', prefixes, all=False)
+        self.iyp.batch_add_node_label(list(prefix_id.values()), 'Prefix')
         country_id = self.iyp.batch_get_nodes_by_single_prop('Country', 'country_code', countries, all=False)
 
         # Replace with QIDs

--- a/iyp/crawlers/pch/__init__.py
+++ b/iyp/crawlers/pch/__init__.py
@@ -297,8 +297,8 @@ class RoutingSnapshotCrawler(BaseCrawler):
 
         # Get/push nodes.
         as_ids = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', ases, all=False)
-        prefix_ids = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-        self.iyp.batch_add_node_label(list(prefix_ids.values()), 'BGPPrefix')
+        prefix_ids = self.iyp.batch_get_nodes_by_single_prop('BGPPrefix', 'prefix', prefixes, all=False)
+        self.iyp.batch_add_node_label(list(prefix_ids.values()), 'Prefix')
 
         # Push relationships.
         relationships = list()

--- a/iyp/crawlers/peeringdb/ix.py
+++ b/iyp/crawlers/peeringdb/ix.py
@@ -221,8 +221,8 @@ class Crawler(BaseCrawler):
                             net_website.add(network['website'])
                         handle_social_media(network, net_website)
 
-        self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefixes, all=False)
-        self.iyp.batch_add_node_label(list(self.prefix_id.values()), 'PeeringLAN')
+        self.prefix_id = self.iyp.batch_get_nodes_by_single_prop('PeeringLAN', 'prefix', prefixes, all=False)
+        self.iyp.batch_add_node_label(list(self.prefix_id.values()), 'Prefix')
         self.name_id = self.iyp.batch_get_nodes_by_single_prop('Name', 'name', net_names)
         self.website_id = self.iyp.batch_get_nodes_by_single_prop('URL', 'url', net_website)
         self.netid_id = self.iyp.batch_get_nodes_by_single_prop(NETID_LABEL, 'id', net_extid)

--- a/iyp/crawlers/ripe/roa.py
+++ b/iyp/crawlers/ripe/roa.py
@@ -78,8 +78,8 @@ class Crawler(BaseCrawler):
 
             # get ASNs and prefixes IDs
             asn_id = self.iyp.batch_get_nodes_by_single_prop('AS', 'asn', asns)
-            prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', set(prefix_info.keys()), all=False)
-            self.iyp.batch_add_node_label(list(prefix_id.values()), 'RPKIPrefix')
+            prefix_id = self.iyp.batch_get_nodes_by_single_prop('RPKIPrefix', 'prefix', set(prefix_info.keys()), all=False)
+            self.iyp.batch_add_node_label(list(prefix_id.values()), 'Prefix')
 
             links = []
             for prefix, attributes in prefix_info.items():

--- a/iyp/crawlers/simulamet/rirdata_rdns.py
+++ b/iyp/crawlers/simulamet/rirdata_rdns.py
@@ -147,8 +147,8 @@ class Crawler(BaseCrawler):
 
         ns_id = self.iyp.batch_get_nodes_by_single_prop('HostName', 'name', ns_set, all=False)
         self.iyp.batch_add_node_label(list(ns_id.values()), 'AuthoritativeNameServer')
-        prefix_id = self.iyp.batch_get_nodes_by_single_prop('Prefix', 'prefix', prefix_set, all=False)
-        self.iyp.batch_add_node_label(list(prefix_id.values()), 'RDNSPrefix')
+        prefix_id = self.iyp.batch_get_nodes_by_single_prop('RDNSPrefix', 'prefix', prefix_set, all=False)
+        self.iyp.batch_add_node_label(list(prefix_id.values()), 'Prefix')
 
         logging.info('Computing relationships')
         links_managed_by = list()

--- a/iyp/post/ip2prefix.py
+++ b/iyp/post/ip2prefix.py
@@ -56,7 +56,6 @@ class PostProcess(BasePostProcess):
         ip_id = self.iyp.batch_get_nodes_by_single_prop('IP', 'ip', batch_size=100000)
 
         # Compute links for IPs
-        # We use a dictionary to avoid having duplicate links
         links = []
         for ip, ip_qid in ip_id.items():
             if ip:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR addresses the problem raised in #190 about the difficulties to relate node for different prefix types.

## Description

It splits nodes of different prefix types, so that a node has only one sub-prefix type. And it removes the `prefix_types` property that is not needed anymore. After this change multiple `Prefix` (the generic type) nodes can have the same `prefix` property.

## Motivation and Context

See #190.

## How Has This Been Tested?

I did a full run of create_db (minus cloudflare and ooni).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

