### PR TITLE
Add Helm chart

### DIFF
--- a/charts/iyp/Chart.yaml
+++ b/charts/iyp/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: iyp
+description: Internet Yellow Pages - Neo4j database with TLS support
+type: application
+version: 0.1.0
+appVersion: "5.26.3"
+keywords:
+  - neo4j
+  - database
+  - internet
+  - topology
+home: https://github.com/InternetHealthReport/internet-yellow-pages
+sources:
+  - https://github.com/InternetHealthReport/internet-yellow-pages
+maintainers:
+  - name: IHR Team
+    url: https://github.com/InternetHealthReport

--- a/charts/iyp/templates/_helpers.tpl
+++ b/charts/iyp/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "iyp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "iyp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "iyp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "iyp.labels" -}}
+helm.sh/chart: {{ include "iyp.chart" . }}
+{{ include "iyp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "iyp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "iyp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/iyp/templates/certificate.yaml
+++ b/charts/iyp/templates/certificate.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.certificate.enabled -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "iyp.fullname" . }}-cert
+  labels:
+    {{- include "iyp.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.certificate.secretName }}
+  issuerRef:
+    name: {{ .Values.certificate.issuer }}
+    kind: ClusterIssuer
+  commonName: {{ .Values.certificate.commonName }}
+  dnsNames:
+    {{- range .Values.certificate.dnsNames }}
+    - {{ . }}
+    {{- end }}
+{{- end }}

--- a/charts/iyp/templates/ingress.yaml
+++ b/charts/iyp/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "iyp.fullname" . }}
+  labels:
+    {{- include "iyp.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if .pathType }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "iyp.fullname" $ }}
+                port:
+                  name: https
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/iyp/templates/pvc-dumps.yaml
+++ b/charts/iyp/templates/pvc-dumps.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.dumps.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "iyp.fullname" . }}-dumps
+  labels:
+    {{- include "iyp.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.dumps.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.dumps.size }}
+  {{- if .Values.persistence.dumps.storageClass }}
+  storageClassName: {{ .Values.persistence.dumps.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/iyp/templates/service-headless.yaml
+++ b/charts/iyp/templates/service-headless.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "iyp.fullname" . }}-headless
+  labels:
+    {{- include "iyp.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    {{- include "iyp.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.ports.https }}
+      targetPort: https
+      protocol: TCP
+      name: https
+    - port: {{ .Values.service.ports.bolt }}
+      targetPort: bolt
+      protocol: TCP
+      name: bolt

--- a/charts/iyp/templates/service.yaml
+++ b/charts/iyp/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "iyp.fullname" . }}
+  labels:
+    {{- include "iyp.labels" . | nindent 4 }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.metallb.pool }}
+  annotations:
+    metallb.universe.tf/address-pool: {{ .Values.service.metallb.pool }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.ports.https }}
+      targetPort: https
+      protocol: TCP
+      name: https
+    - port: {{ .Values.service.ports.bolt }}
+      targetPort: bolt
+      protocol: TCP
+      name: bolt
+  selector:
+    {{- include "iyp.selectorLabels" . | nindent 4 }}

--- a/charts/iyp/templates/statefulset.yaml
+++ b/charts/iyp/templates/statefulset.yaml
@@ -1,0 +1,289 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "iyp.fullname" . }}
+  labels:
+    {{- include "iyp.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "iyp.fullname" . }}-headless
+  replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: OrderedReady
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
+  selector:
+    matchLabels:
+      {{- include "iyp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "iyp.selectorLabels" . | nindent 8 }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 300 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- if .Values.initContainers.downloadDump.enabled }}
+        - name: download-dump
+          image: "{{ .Values.initContainers.downloadDump.image.repository }}:{{ .Values.initContainers.downloadDump.image.tag }}"
+          imagePullPolicy: {{ .Values.initContainers.downloadDump.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              DUMP_URL="{{ .Values.initContainers.downloadDump.dumpUrl }}"
+              FILENAME=$(basename "$DUMP_URL")
+              TARGET_FILE="/dumps/$FILENAME"
+              SYMLINK="/dumps/neo4j.dump"
+
+              echo "Checking for existing dump file..."
+
+              # Check if the target file already exists
+              if [ -f "$TARGET_FILE" ]; then
+                echo "File $FILENAME already exists, skipping download"
+              else
+                echo "File $FILENAME not found"
+
+                # Clean up any existing files and symlink
+                if [ -L "$SYMLINK" ]; then
+                  echo "Removing old symlink"
+                  rm "$SYMLINK"
+                fi
+
+                # Remove any old dump files
+                rm -f /dumps/*.dump
+
+                echo "Downloading database dump from $DUMP_URL"
+                curl -L -o "$TARGET_FILE" "$DUMP_URL"
+
+                if [ $? -eq 0 ]; then
+                  echo "Database dump downloaded successfully as $FILENAME"
+                else
+                  echo "Failed to download database dump"
+                  exit 1
+                fi
+              fi
+
+              # Create or update symlink
+              if [ ! -L "$SYMLINK" ] || [ "$(readlink "$SYMLINK")" != "$FILENAME" ]; then
+                echo "Creating symlink: neo4j.dump -> $FILENAME"
+                ln -sf "$FILENAME" "$SYMLINK"
+              else
+                echo "Symlink already exists and is correct"
+              fi
+
+              echo "Download process completed"
+          volumeMounts:
+            - name: dumps-volume
+              mountPath: /dumps
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- end }}
+        {{- if .Values.initContainers.loadDatabase.enabled }}
+        - name: load-database
+          image: "{{ .Values.loaderImage.repository }}:{{ .Values.loaderImage.tag }}"
+          imagePullPolicy: {{ .Values.loaderImage.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Checking for existing neo4j database..."
+
+              # Check if neo4j database exists and delete it
+              if [ -d "/data/databases/neo4j" ]; then
+                echo "Found existing neo4j database, deleting..."
+                rm -rf /data/databases/neo4j
+                echo "Existing database deleted"
+              fi
+
+              # Also remove transaction logs if they exist
+              if [ -d "/data/transactions/neo4j" ]; then
+                echo "Found existing transaction logs, deleting..."
+                rm -rf /data/transactions/neo4j
+                echo "Transaction logs deleted"
+              fi
+
+              echo "Running database load command..."
+              exec neo4j-admin database load neo4j --from-path=/dumps --verbose
+          volumeMounts:
+            - name: neo4j-data
+              mountPath: /data
+            - name: dumps-volume
+              mountPath: /dumps
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          lifecycle:
+            {{- if .Values.neo4j.apoc.enabled }}
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "cp /var/lib/neo4j/labs/apoc-*.jar /var/lib/neo4j/plugins/ || true"]
+            {{- end }}
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "cypher-shell -u neo4j -p $NEO4J_AUTH 'CALL dbms.shutdown()' || true"]
+          ports:
+            - name: https
+              containerPort: 7473
+              protocol: TCP
+            - name: bolt
+              containerPort: 7687
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          env:
+            - name: NEO4J_AUTH
+              value: "{{ if .Values.neo4j.auth.enabled }}neo4j/password{{ else }}none{{ end }}"
+            - name: NEO4J_server_default__listen__address
+              value: "{{ .Values.neo4j.server.defaultListenAddress }}"
+            {{- if .Values.neo4j.server.defaultAdvertisedAddress }}
+            - name: NEO4J_server_default__advertised__address
+              value: "{{ .Values.neo4j.server.defaultAdvertisedAddress }}"
+            {{- else if .Values.ingress.enabled }}
+            - name: NEO4J_server_default__advertised__address
+              value: "{{ (index .Values.ingress.hosts 0).host }}"
+            {{- end }}
+            - name: NEO4J_server_databases_default__to__read__only
+              value: "{{ .Values.neo4j.server.readOnly }}"
+            - name: NEO4J_server_directories_logs
+              value: "/logs"
+            - name: NEO4J_server_https_enabled
+              value: "{{ .Values.neo4j.tls.https.enabled }}"
+            - name: NEO4J_server_https_listen__address
+              value: ":7473"
+            - name: NEO4J_server_https_advertised__address
+              value: ":7473"
+            - name: NEO4J_server_bolt_enabled
+              value: "{{ .Values.neo4j.tls.bolt.enabled }}"
+            - name: NEO4J_server_bolt_tls__level
+              value: "{{ if .Values.neo4j.tls.enabled }}OPTIONAL{{ else }}DISABLED{{ end }}"
+            - name: NEO4J_server_bolt_listen__address
+              value: ":7687"
+            - name: NEO4J_server_bolt_advertised__address
+              value: ":7687"
+            - name: NEO4J_server_http_enabled
+              value: "false"
+            {{- if .Values.neo4j.tls.enabled }}
+            - name: NEO4J_dbms_ssl_policy_bolt_enabled
+              value: "{{ .Values.neo4j.tls.bolt.enabled }}"
+            - name: NEO4J_dbms_ssl_policy_bolt_base__directory
+              value: "{{ .Values.neo4j.tls.bolt.baseDirectory }}"
+            - name: NEO4J_dbms_ssl_policy_bolt_private__key
+              value: "{{ .Values.neo4j.tls.bolt.privateKey }}"
+            - name: NEO4J_dbms_ssl_policy_bolt_public__certificate
+              value: "{{ .Values.neo4j.tls.bolt.publicCertificate }}"
+            - name: NEO4J_dbms_ssl_policy_https_enabled
+              value: "{{ .Values.neo4j.tls.https.enabled }}"
+            - name: NEO4J_dbms_ssl_policy_https_base__directory
+              value: "{{ .Values.neo4j.tls.https.baseDirectory }}"
+            - name: NEO4J_dbms_ssl_policy_https_private__key
+              value: "{{ .Values.neo4j.tls.https.privateKey }}"
+            - name: NEO4J_dbms_ssl_policy_https_public__certificate
+              value: "{{ .Values.neo4j.tls.https.publicCertificate }}"
+            {{- end }}
+            {{- if .Values.neo4j.memory.heap.initial }}
+            - name: NEO4J_server_memory_heap_initial__size
+              value: "{{ .Values.neo4j.memory.heap.initial }}"
+            {{- end }}
+            {{- if .Values.neo4j.memory.heap.max }}
+            - name: NEO4J_server_memory_heap_max__size
+              value: "{{ .Values.neo4j.memory.heap.max }}"
+            {{- end }}
+            {{- if .Values.neo4j.memory.pagecache }}
+            - name: NEO4J_server_memory_pagecache_size
+              value: "{{ .Values.neo4j.memory.pagecache }}"
+            {{- end }}
+            - name: NEO4J_browser_remote__content__hostname__whitelist
+              value: "*"
+            - name: NEO4J_browser_post__connect__cmd
+              value: "play https://{{ (index .Values.ingress.hosts 0).host }}/guides/start.html"
+            {{- if .Values.neo4j.apoc.enabled }}
+            - name: NEO4J_PLUGINS
+              value: "apoc"
+            - name: NEO4J_dbms_security_procedures_unrestricted
+              value: "apoc.*"
+            {{- end }}
+          volumeMounts:
+            - name: neo4j-data
+              mountPath: /data
+            {{- if .Values.neo4j.tls.enabled }}
+            - name: ssl-certs
+              mountPath: /ssl/certificates/https/neo4j.key
+              subPath: tls.key
+              readOnly: true
+            - name: ssl-certs
+              mountPath: /ssl/certificates/https/neo4j.cert
+              subPath: tls.crt
+              readOnly: true
+            - name: ssl-certs
+              mountPath: /ssl/certificates/bolt/neo4j.key
+              subPath: tls.key
+              readOnly: true
+            - name: ssl-certs
+              mountPath: /ssl/certificates/bolt/neo4j.cert
+              subPath: tls.crt
+              readOnly: true
+            {{- end }}
+            - name: logs-volume
+              mountPath: /logs
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      volumes:
+        - name: dumps-volume
+          {{- if .Values.persistence.dumps.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "iyp.fullname" . }}-dumps
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.neo4j.tls.enabled }}
+        - name: ssl-certs
+          secret:
+            secretName: {{ .Values.certificate.secretName }}
+        {{- end }}
+        - name: logs-volume
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: neo4j-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      {{- if .Values.persistence.data.storageClass }}
+      storageClassName: {{ .Values.persistence.data.storageClass }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.data.size }}

--- a/charts/iyp/values.yaml
+++ b/charts/iyp/values.yaml
@@ -1,0 +1,157 @@
+image:
+  repository: neo4j
+  tag: "5.26.3"
+  pullPolicy: IfNotPresent
+
+loaderImage:
+  repository: neo4j/neo4j-admin
+  tag: "5.26.2-community-debian"
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+# Graceful shutdown timeout in seconds
+terminationGracePeriodSeconds: 300
+
+# Init container configuration
+initContainers:
+  # First init container: Download data dump from remote URL
+  downloadDump:
+    # set to false to disable the download dump init container
+    enabled: true
+    image:
+      repository: curlimages/curl
+      tag: "8.10.1"
+      pullPolicy: IfNotPresent
+    # URL to download the database dump from
+    dumpUrl: "https://archive.ihr.live/ihr/iyp/YYYY/MM/DD/iyp-YYYY-MM-DD.dump"
+
+  # Second init container: Load the dump into Neo4j
+  loadDatabase:
+    # set to false to disable the load database init container. If enabled, this initContainer will delete any existing database and load the dump
+    enabled: true
+
+# Neo4j configuration
+neo4j:
+  auth:
+    enabled: false
+
+  # APOC plugin configuration
+  apoc:
+    enabled: true
+
+  # TLS configuration
+  tls:
+    enabled: true
+    bolt:
+      enabled: true
+      baseDirectory: "/ssl/certificates/bolt"
+      privateKey: "neo4j.key"
+      publicCertificate: "neo4j.cert"
+    https:
+      enabled: true
+      baseDirectory: "/ssl/certificates/https"
+      privateKey: "neo4j.key"
+      publicCertificate: "neo4j.cert"
+
+  # Server configuration
+  server:
+    defaultListenAddress: "0.0.0.0"
+    defaultAdvertisedAddress: ""  # Will be set by ingress hostname
+    readOnly: true
+
+  # Memory settings
+  memory:
+    heap:
+      initial: "512m"
+      max: "1024m"
+    pagecache: "1g"
+
+# Service configuration
+service:
+  type: ClusterIP
+  ports:
+    https: 7473
+    bolt: 7687
+  # MetalLB configuration (only applies when service.type is LoadBalancer)
+  metallb:
+    # Specify MetalLB IP pool name to request IP from specific pool
+    pool: ""
+    # Example: pool: "public-pool"
+
+# Ingress configuration
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+  hosts:
+    - host: iyp.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: iyp-tls
+      hosts:
+        - iyp.example.com
+
+# Certificate configuration
+certificate:
+  enabled: true
+  issuer: "letsencrypt-prod"
+  secretName: "iyp-tls"
+  commonName: "iyp.example.com"
+  dnsNames:
+    - "iyp.example.com"
+
+# Persistent Volume configuration
+persistence:
+  data:
+    enabled: true
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 200Gi
+    mountPath: /data
+
+  dumps:
+    enabled: true
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 20Gi
+    mountPath: /dumps
+
+# Resource limits
+resources:
+  limits:
+    cpu: 2000m
+    memory: 4Gi
+  requests:
+    cpu: 500m
+    memory: 1Gi
+
+# Node selector
+nodeSelector: {}
+
+# Tolerations
+tolerations: []
+
+# Affinity
+affinity: {}
+
+# Security context (for containers)
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 7474
+  runAsGroup: 7474
+
+# Pod security context
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 7474
+  runAsGroup: 7474
+  fsGroup: 7474


### PR DESCRIPTION
Initial helm chart, needs some work.
TLS isn't working properly.
Updating the NEO4J DB needs some work.
Documentation needed - especially for DB update procedure.

## Description

Adds Helm chart to install a Neo4j server using persistent storage. Configures Services and Ingress. Downloads an IYP dump as defined in a values.yaml file and loads the dump. Has a rudimentary procedure for updating to the latest dump. This process needs some work.
TLS is not working yet. There are a handful of knobs in Neo4j that need to match in order to get TLS working.

## Motivation and Context

Provides a Helm chart to install IYP and dependencies on a Kubernetes cluster. This should make it easier for people running kubernetes to run a local instance of IYP.

## How Has This Been Tested?

This is currently being used in a test environment. I can provide details and access if requested.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

