### PR TITLE
Updated ipv4 detection in address_family.py

### DIFF
--- a/iyp/post/address_family.py
+++ b/iyp/post/address_family.py
@@ -12,15 +12,18 @@ class PostProcess(BasePostProcess):
         """Add address family (4 or 6 for IPv4 or IPv6) to all IP and Prefix nodes."""
 
         # Update prefixes
-        self.iyp.tx.run("MATCH (pfx:Prefix) WHERE pfx.prefix CONTAINS '.' SET pfx.af = 4")
-        self.iyp.commit()
         self.iyp.tx.run("MATCH (pfx:Prefix) WHERE pfx.prefix CONTAINS ':' SET pfx.af = 6")
+        self.iyp.commit()
+        self.iyp.tx.run(
+            "MATCH (pfx:Prefix) WHERE pfx.prefix CONTAINS '.' "
+            "AND NOT pfx.prefix CONTAINS ':' SET pfx.af = 4"
+        )
         self.iyp.commit()
 
         # Update IP addresses
-        self.iyp.tx.run("MATCH (ip:IP) WHERE ip.ip CONTAINS '.' SET ip.af = 4")
-        self.iyp.commit()
         self.iyp.tx.run("MATCH (ip:IP) WHERE ip.ip CONTAINS ':' SET ip.af = 6")
+        self.iyp.commit()
+        self.iyp.tx.run("MATCH (ip:IP) WHERE ip.ip CONTAINS '.' AND NOT ip.ip CONTAINS ':' SET ip.af = 4")
         self.iyp.commit()
 
     def rerun(self):


### PR DESCRIPTION
## Description
Inside `address_family.py` in iyp/post, I have just updated the way ipv4 is handled. IPv6 is checked first ((includes IPv4-mapped addresses), then we check for pure IPv4 address.
```
self.iyp.tx.run(
        "MATCH (pfx:Prefix) WHERE pfx.prefix CONTAINS '.' "
        "AND NOT pfx.prefix CONTAINS ':' SET pfx.af = 4"
    )
```
we do the same when we update ip address

## Motivation and Context

Previously -
`::ffff:192.0.2.1/128` -> af = 6 (fails)
`64:ff9b::192.0.2.33/128` -> af = 6 (fails)
This could lead to incorrect address family classification
Now it checks for that. 
This PR fixes #203 

## How Has This Been Tested?
Minimal fixes, I guess no new tests are required for this.

## Screenshots (if appropriate): Not applicat=ble

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

