### PR TITLE
[MCP] Fix prohibitive Neo4j schema size and implement schema projection

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   iyp_loader:
     image: neo4j/neo4j-admin:2026-community-debian
-    profiles: ["local", "public_tls", "public_notls", "mcp"]
+    profiles: ["local", "public_tls", "public_notls"]
     user: "${uid}:${gid}"
     container_name: iyp_loader
     tty: true
@@ -36,6 +36,13 @@ services:
     depends_on:
       iyp_loader:
         condition: service_completed_successfully
+
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:7474"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
   iyp_readonly_tls:
     image: neo4j:5.26.21
@@ -93,54 +100,19 @@ services:
       - caddy_config:/config
     command: /usr/bin/caddy run --resume
 
-  iyp_apoc:
-    image: neo4j:5.26.17
-    profiles: ["mcp"]
-    user: "${uid}:${gid}"
-    container_name: iyp
-    restart: unless-stopped
-    ports:
-      - 7474:7474
-      - 7687:7687
-    volumes:
-      - ./data:/data
-    environment:
-      - NEO4J_AUTH=neo4j/password
-      - NEO4J_PLUGINS=["apoc"]
-    depends_on:
-      iyp_loader:
-        condition: service_completed_successfully
-
-  iyp_mcp_neo4j:
-    image: mcp/neo4j-cypher:latest
-    profiles: ["mcp"]
-    user: "${uid}:${gid}"
-    container_name: iyp_mcp_neo4j
-    ports:
-      - '8001:8000'
-    environment:
-      - NEO4J_URI=bolt://iyp_apoc:7687
-      - NEO4J_USERNAME=neo4j
-      - NEO4J_PASSWORD=password
-      - NEO4J_DATABASE=neo4j
-      - NEO4J_TRANSPORT=http
-      - NEO4J_MCP_SERVER_HOST=0.0.0.0 # must be 0.0.0.0 for sse  or http transport in Docker
-      - NEO4J_MCP_SERVER_PORT=8000
-      - NEO4J_MCP_SERVER_PATH=/api/mcp/
-      - NEO4J_NAMESPACE=local
-    depends_on:
-      - iyp_apoc
-
-  iyp_mcp_doc:
+  iyp_mcp:
     image: python:3.12-slim-trixie
-    profiles: ["mcp"]
-    container_name: iyp_mcp_doc
+    profiles: ["local"]
+    container_name: iyp_mcp
     working_dir: /app
     volumes:
       - ./:/app:ro
     ports:
-      - '8002:8002'
-    command: bash -c "pip install pandas 'mcp[cli]' pydantic && python -m mcp_server.server"
+      - '8010:8010'
+    command: bash -c "pip install pandas==2.3.3 fastmcp==2.14.4 pydantic==2.12.5 neo4j==6.1.0 tiktoken==0.12.0 && python -m mcp_server.server --port 8010 --sample-size 1000 --neo4j-read-timeout 60"
+    depends_on:
+      iyp:
+        condition: service_healthy
 
 volumes:
   caddy_data:

--- a/mcp_example/pydanticai_client.py
+++ b/mcp_example/pydanticai_client.py
@@ -35,7 +35,7 @@ system_prompt = (
     'You are a highly sophisticated automated agent with expert-level knowledge '
     'about the Internet.\n'
     'If the user asks for factual data, retrieve '
-    "it by querying IYP with neo4j's Cypher language.\n"
+    "it by querying IYP with neo4j's Cypher language (get the schema before).\n"
     'If the user asks for meta-data or explanations about the data, '
     'retrieve the relevant information with the IYP documentation tool.\n'
     "Reply \"Sorry, I can't assist with that.\" if the user's request is not "
@@ -55,11 +55,15 @@ ollama_model = OpenAIChatModel(
     ),
 )
 
-doc_server = MCPServerStreamableHTTP('http://localhost:8002/mcp')
-neo4j_server = MCPServerStreamableHTTP('http://localhost:8001/api/mcp')
+mcp_server = MCPServerStreamableHTTP('http://localhost:8010/mcp')
+
+# Recommended: Use get_neo4j_schema_projected instead of get_neo4j_schema
+filtered_tools = mcp_server.filtered(
+    lambda ctx, tool: tool.name != 'get_neo4j_schema'
+)
 
 agent = Agent(
-    ollama_model, toolsets=[doc_server, neo4j_server], system_prompt=system_prompt
+    ollama_model, toolsets=[mcp_server], system_prompt=system_prompt
 )
 
 result = agent.run_sync(

--- a/mcp_example/pydanticai_client.py
+++ b/mcp_example/pydanticai_client.py
@@ -63,11 +63,11 @@ filtered_tools = mcp_server.filtered(
 )
 
 agent = Agent(
-    ollama_model, toolsets=[mcp_server], system_prompt=system_prompt
+    ollama_model, toolsets=[filtered_tools], system_prompt=system_prompt
 )
 
 result = agent.run_sync(
-    'Give me the list of IXPs where AS2497 is present and explain me where the data comes from.'
+    'Give me the list of IXPs where AS2497 is present, get the name of AS2497 and explain me where the data comes from.'
 )
 
 print(result.all_messages())

--- a/mcp_server/mcp_neo4j/schema.py
+++ b/mcp_server/mcp_neo4j/schema.py
@@ -1,0 +1,116 @@
+# MIT License
+
+# Copyright (c) 2024-2025 Neo4j
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import logging
+
+from neo4j import AsyncDriver, RoutingControl
+
+logger = logging.getLogger('mcp_neo4j_cypher')
+
+
+DISCARD_EDGE_PROPERTIES = [
+    'reference_time_fetch',
+    'reference_url_info',
+    'reference_time_modification',
+    'reference_url_data']
+
+
+def simplify_node_properties(properties: dict) -> list[str]:
+    """Collapse in a list and filter out `existence`, `array` and `indexed`"""
+    return [f"{key} ({val['type']})" for key, val in properties.items()]
+
+
+def simplify_relationship_properties(properties: dict) -> list[str]:
+    """Collapse in a list and filter out `existence`, `array` and `indexed`.
+
+    Also remove non-essential properties.
+    """
+    return [f"{key} ({val['type']})" for key, val in properties.items() if key not in DISCARD_EDGE_PROPERTIES]
+
+
+def clean_schema(schema: dict) -> dict:
+    """Modified version of neo4j's to reduce APOC schema inspection verbosity."""
+    cleaned = {}
+
+    for key, entry in schema.items():
+
+        # node or relationship
+        entry_type = entry['type']
+        new_entry = {'type': entry_type}
+        if 'count' in entry:
+            new_entry['count'] = entry['count']
+
+        labels = entry.get('labels', [])
+        if labels:
+            new_entry['labels'] = labels
+
+        props = entry.get('properties', {})
+        if props:
+            if entry_type == 'node':
+                new_entry['properties'] = simplify_node_properties(props)
+            elif entry_type == 'relationship':
+                new_entry['properties'] = simplify_relationship_properties(props)
+            else:
+                raise ValueError(f'Unknown schema entry type: {entry_type}')
+
+        if entry.get('relationships'):
+            rels_out = {}
+            for rel_name, rel in entry['relationships'].items():
+                clean_rel = {}
+                if 'direction' in rel:
+                    clean_rel['direction'] = rel['direction']
+                # nested labels
+                rel_labels = rel.get('labels', [])
+                if rel_labels:
+                    clean_rel['labels'] = rel_labels
+                # nested properties
+                rel_props = rel.get('properties', {})
+                clean_rel['properties'] = simplify_relationship_properties(rel_props)
+                if clean_rel:
+                    rels_out[rel_name] = clean_rel
+
+            if rels_out:
+                new_entry['relationships'] = rels_out
+
+        cleaned[key] = new_entry
+
+    return cleaned
+
+
+async def retrieve_schema(neo4j_driver: AsyncDriver, sample_size: int = 100) -> dict:
+    """Call APOC procedure to retrieve the schema."""
+
+    logger.info(f'Running `get_neo4j_schema` with sample size {sample_size}.'
+                f'(this might take few minutes)')
+
+    get_schema_query = f'CALL apoc.meta.schema({{sample: {sample_size}}}) YIELD value RETURN value'
+
+    results_json = await neo4j_driver.execute_query(
+        get_schema_query,
+        routing_control=RoutingControl.READ,
+        database_='neo4j',
+        result_transformer_=lambda r: r.data(),
+    )
+
+    schema_clean = clean_schema(results_json[0].get('value'))
+
+    return schema_clean

--- a/mcp_server/mcp_neo4j/schema.py
+++ b/mcp_server/mcp_neo4j/schema.py
@@ -97,7 +97,12 @@ def clean_schema(schema: dict) -> dict:
 
 
 async def retrieve_schema(neo4j_driver: AsyncDriver, sample_size: int = 100) -> dict:
-    """Call APOC procedure to retrieve the schema."""
+    """Call APOC procedure to retrieve the schema.
+
+    `sample_size` is the sample size used to infer the graph schema.
+    Larger samples are slower, but more accurate.
+    Smaller samples are faster, but might miss information.
+    """
 
     logger.info(f'Running `get_neo4j_schema` with sample size {sample_size}.'
                 f'(this might take few minutes)')

--- a/mcp_server/mcp_neo4j/utils.py
+++ b/mcp_server/mcp_neo4j/utils.py
@@ -1,0 +1,125 @@
+# MIT License
+
+# Copyright (c) 2024-2025 Neo4j
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import logging
+import re
+from typing import Any
+
+import tiktoken
+
+logger = logging.getLogger('mcp_neo4j_cypher')
+logger.setLevel(logging.INFO)
+
+
+def is_write_query(query: str) -> bool:
+    """Check if the query is a write query."""
+    return (
+        re.search(r'\b(MERGE|CREATE|INSERT|SET|DELETE|REMOVE|ADD)\b', query, re.IGNORECASE)
+        is not None
+    )
+
+
+def value_sanitize(d: Any, list_limit: int = 128) -> Any:
+    """Sanitize the input dictionary or list.
+
+    Sanitizes the input by removing embedding-like values,
+    lists with more than 128 elements, that are mostly irrelevant for
+    generating answers in a LLM context. These properties, if left in
+    results, can occupy significant context space and detract from
+    the LLM's performance by introducing unnecessary noise and cost.
+
+
+    Parameters
+    ----------
+    d : Any
+        The input dictionary or list to sanitize.
+    list_limit : int
+        The limit for the number of elements in a list.
+
+    Returns
+    -------
+    Any
+        The sanitized dictionary or list.
+    """
+    if isinstance(d, dict):
+        new_dict = {}
+        for key, value in d.items():
+            if isinstance(value, dict):
+                sanitized_value = value_sanitize(value)
+                if (
+                    sanitized_value is not None
+                ):  # Check if the sanitized value is not None
+                    new_dict[key] = sanitized_value
+            elif isinstance(value, list):
+                if len(value) < list_limit:
+                    sanitized_value = value_sanitize(value)
+                    if (
+                        sanitized_value is not None
+                    ):  # Check if the sanitized value is not None
+                        new_dict[key] = sanitized_value
+                # Do not include the key if the list is oversized
+            else:
+                new_dict[key] = value
+        return new_dict
+    elif isinstance(d, list):
+        if len(d) < list_limit:
+            return [
+                value_sanitize(item) for item in d if value_sanitize(item) is not None
+            ]
+        else:
+            return None
+    else:
+        return d
+
+
+def truncate_string_to_tokens(
+    text: str, token_limit: int, model: str = 'gpt-4'
+) -> str:
+    """Truncates the input string to fit within the specified token limit.
+
+    Parameters
+    ----------
+    text : str
+        The input text string.
+    token_limit : int
+        Maximum number of tokens allowed.
+    model : str
+        Model name (affects tokenization). Defaults to "gpt-4".
+
+    Returns
+    -------
+    str
+        The truncated string that fits within the token limit.
+    """
+    # Load encoding for the chosen model
+    encoding = tiktoken.encoding_for_model(model)
+
+    # Encode text into tokens
+    tokens = encoding.encode(text)
+
+    # Truncate tokens if they exceed the limit
+    if len(tokens) > token_limit:
+        tokens = tokens[:token_limit]
+
+    # Decode back into text
+    truncated_text = encoding.decode(tokens)
+    return truncated_text

--- a/mcp_server/mcp_neo4j/utils.py
+++ b/mcp_server/mcp_neo4j/utils.py
@@ -21,21 +21,12 @@
 # SOFTWARE.
 
 import logging
-import re
 from typing import Any
 
 import tiktoken
 
 logger = logging.getLogger('mcp_neo4j_cypher')
 logger.setLevel(logging.INFO)
-
-
-def is_write_query(query: str) -> bool:
-    """Check if the query is a write query."""
-    return (
-        re.search(r'\b(MERGE|CREATE|INSERT|SET|DELETE|REMOVE|ADD)\b', query, re.IGNORECASE)
-        is not None
-    )
 
 
 def value_sanitize(d: Any, list_limit: int = 128) -> Any:

--- a/mcp_server/mcp_neo4j/utils.py
+++ b/mcp_server/mcp_neo4j/utils.py
@@ -84,7 +84,7 @@ def value_sanitize(d: Any, list_limit: int = 128) -> Any:
 
 def truncate_string_to_tokens(
     text: str, token_limit: int, model: str = 'gpt-4'
-) -> str:
+) -> tuple[str, bool]:
     """Truncates the input string to fit within the specified token limit.
 
     Parameters
@@ -108,9 +108,11 @@ def truncate_string_to_tokens(
     tokens = encoding.encode(text)
 
     # Truncate tokens if they exceed the limit
+    is_truncated = False
     if len(tokens) > token_limit:
         tokens = tokens[:token_limit]
+        is_truncated = True
 
     # Decode back into text
     truncated_text = encoding.decode(tokens)
-    return truncated_text
+    return truncated_text, is_truncated

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,167 +1,371 @@
-from typing import Literal
+# MIT License
 
-from mcp.server.fastmcp import FastMCP
-from pydantic import Field
+# Copyright (c) 2024-2025 Neo4j
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import argparse
+import asyncio
+import json
+import logging
+from typing import Any, Literal
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from neo4j import AsyncGraphDatabase, Query, RoutingControl
+from neo4j.exceptions import Neo4jError
+from pydantic import BaseModel, Field
 
 from mcp_server.documentation.models import (DatasetBase, DatasetFull,
                                              NodeType, RelationshipType)
 from mcp_server.documentation.parsers import (parse_datasets, parse_node_types,
                                               parse_relationship_types)
+from mcp_server.mcp_neo4j.schema import retrieve_schema
+from mcp_server.mcp_neo4j.utils import (is_write_query,
+                                        truncate_string_to_tokens,
+                                        value_sanitize)
 
-# Load documentation
+# Setup Logging
+logger = logging.getLogger('mcp_neo4j_cypher')
+logger.setLevel(logging.INFO)
+
+# Constants
+
+
+class ServerConfig(BaseModel):
+    neo4j_read_timeout: int = Field(default=60, description='Timemout for Neo4j read in seconds (default 60)')
+    token_limit: int | None = Field(default=None, description='GPT token limit per response (default None)')
+    port: int = Field(default=8010)
+    sample_size: int = Field(default=5000, description='Sample size used when querying the schema at server startup')
+
+
+config = ServerConfig()
+
 datasets = {dataset.reference_name: dataset for dataset in parse_datasets()}
 node_types = {node_type.name: node_type for node_type in parse_node_types()}
 rel_types = {rel_type.name: rel_type for rel_type in parse_relationship_types()}
 
-instructions = (
-    'This MCP server exposes the Internet Yellow Pages (IYP) documentation. '
-    'IYP is an open source Neo4j knowledge database that gathers information '
-    'about Internet resources (for example ASNs, IP prefixes, and domain names).'
-)
 
-mcp = FastMCP(
-    'Internet Yellow Pages (IYP)', host='0.0.0.0', port=8002, instructions=instructions
-)
+# Server factory function following neo4j structure
+# Not an expert but apparently needed for async event context
+def create_mcp_server(neo4j_driver, schema):
+    """Creates the FastMCP server instance with all tools registered.
 
-
-@mcp.tool()
-def list_iyp_datasets() -> list[DatasetBase]:
-    """List a light view of datasets in Internet Yellow Pages.
-
-    For a full description a dataset, call `get_iyp_resource`.
+    We pass the 'neo4j_driver' and 'schema' in as arguments so the tools can close over
+    them safely.
     """
-    # Downcast `DatasetFull` to `DatasetBase`` to save context
-    return [DatasetBase.model_validate(dataset) for dataset in datasets.values()]
+
+    instructions = (
+        'This MCP server exposes the Internet Yellow Pages (IYP) knowledge graph. '
+        'IYP is an open source Neo4j knowledge database that gathers information '
+        'about Internet resources (for example ASNs, IP prefixes, and domain names).'
+        'To help the AI assistant retrieve domain-specific knowledge (Internet concept, datasets)'
+        ', this MCP exposes the documentation and schema of IYP, as well as'
+        'tools to retrieve or modify data in IYP via Cypher queries.'
+        'Using a tool to retrieve the schema before making a cypher query is strongly advised.'
+    )
+
+    mcp = FastMCP(
+        'Internet Yellow Pages (IYP)',
+        instructions=instructions
+    )
+
+    # Part 1: documentation tool
+
+    @mcp.tool()
+    async def list_iyp_datasets() -> list[DatasetBase]:
+        """List a light view of datasets in Internet Yellow Pages."""
+        return [DatasetBase.model_validate(dataset) for dataset in datasets.values()]
+
+    @mcp.tool()
+    async def list_iyp_node_types() -> list[NodeType]:
+        """List all node types in Internet Yellow Pages."""
+        return [node_type for node_type in node_types.values()]
+
+    @mcp.tool()
+    async def list_iyp_relationship_types() -> list[RelationshipType]:
+        """List all relationship types in Internet Yellow Pages."""
+        return [rel_type for rel_type in rel_types.values()]
+
+    # Helper getters for resources
+    def get_iyp_dataset_documentation(reference_name: str) -> DatasetFull:
+        return datasets[reference_name]
+
+    def get_iyp_node_type_documentation(name: str) -> NodeType:
+        return node_types[name]
+
+    def get_iyp_relationship_type_documentation(name: str) -> RelationshipType:
+        return rel_types[name]
+
+    scheme2getter = {
+        'dataset': get_iyp_dataset_documentation,
+        'node-type': get_iyp_node_type_documentation,
+        'relationship-type': get_iyp_relationship_type_documentation,
+    }
+
+    @mcp.tool()
+    async def get_iyp_resource(
+        scheme: Literal['dataset', 'node-type', 'relationship-type'] = Field(
+            description='The scheme to access the resource.',
+        ),
+        name: str = Field(
+            description='Unique identifier of the resource.'
+        ),
+    ):
+        """Get the Internet Yellow Pages documentation associated to the resource."""
+        if scheme not in scheme2getter:
+            raise ToolError(f"Unknown scheme: '{scheme}://'. Supported: dataset, node-type, relationship-type.")
+
+        try:
+            return scheme2getter[scheme](name)
+        except KeyError:
+            raise ToolError(f"Resource '{scheme}://{name}' does not exist")
+        except Exception as e:
+            raise ToolError(f'Unexpected error {e}')
+
+    # Non-templated resource access
+    # Resources are registered one by one to make them discoverable by MCP clients
+    def register_dataset_resource(reference_name: str, dataset: DatasetFull):
+        # Create a specific URI for this dataset
+        uri = f'dataset://{reference_name}'
+
+        dynamic_description = f'Returns documentation of the {dataset.name} dataset.'
+
+        def get_dataset() -> DatasetFull:
+            return dataset
+
+        get_dataset.__doc__ = dynamic_description
+        mcp.resource(uri)(get_dataset)
+
+    for reference_name, dataset in datasets.items():
+        register_dataset_resource(reference_name, dataset)
+
+    def register_node_type_resource(name: str, node_type: NodeType):
+        uri = f'node-type://{name}'
+
+        dynamic_description = f'Returns documentation of the {name} node type'
+
+        def get_node_type() -> NodeType:
+            return node_type
+
+        get_node_type.__doc__ = dynamic_description
+        mcp.resource(uri)(get_node_type)
+
+    for name, node_type in node_types.items():
+        register_node_type_resource(name, node_type)
+
+    def register_relationship_type_resource(name: str, rel_type: RelationshipType):
+        uri = f'relationship-type://{name}'
+
+        dynamic_description = f'Returns documentation of the {name} relation type'
+
+        def get_relationship_type() -> RelationshipType:
+            return rel_type
+
+        get_relationship_type.__doc__ = dynamic_description
+        mcp.resource(uri)(get_relationship_type)
+
+    for name, rel_type in rel_types.items():
+        register_relationship_type_resource(name, rel_type)
+
+    # Part 2: Neo4j tools
+
+    # Version where we force to use specify node types
+    # advantage: reduce context, force LLM to read doc
+    # disadvantage: add more steps, sometimes LLM get it wrong
+    # Use `include_node_types` to project the schema onto a smaller, relevant
+    # subgraph, as the full schema is often too large to process.
+    @mcp.tool()
+    async def get_neo4j_schema_projected(include_node_types: list[str] = Field(
+        description='A list of node types to include in the returned schema.'),
+        include_relationship_types: list[str] = Field(
+        description='An optional list of relationship types to include in the returned schema.',
+        default=[]
+    )
+    ) -> str:
+        """Returns the neo4j schema, including node types, their properties, and
+        relationship types.
+
+        Confirm the node type with `list_iyp_node_types` before calling this tool.
+        """
+
+        if not include_node_types:
+            raise ToolError('Provide a list of node types to project the schema')
+
+        desired_keys = include_node_types + include_relationship_types
+        projected_schema = {}
+
+        for key, entry in schema.items():
+            if key not in desired_keys:
+                continue
+
+            new_entry = {'type': entry['type']}
+
+            if 'count' in entry:
+                new_entry['count'] = entry['count']
+
+            labels = entry.get('labels', [])
+            if labels:
+                new_entry['labels'] = labels
+
+            props = entry.get('properties', {})
+            new_entry['properties'] = props
+
+            rels = entry.get('relationships', {})
+            if rels:
+                simplified_rels = {}
+                for rel_type, data in rels.items():
+                    data = {k: v for k, v in data.items()
+                            if k not in ['properties']}
+                    simplified_rels[rel_type] = data
+                new_entry['relationships'] = simplified_rels
+
+            projected_schema[key] = new_entry
+
+        results_str = json.dumps(projected_schema, default=str)
+        return truncate_string_to_tokens(results_str, config.token_limit) if config.token_limit else results_str
+
+    # Version withouth node types filtering
+    # advantage: less opinionated, less steps
+    # disadvantage: context (around 30k)
+    @mcp.tool()
+    async def get_neo4j_schema() -> str:
+        """Returns the neo4j schema, including node types, their properties, and
+        relationship types."""
+        results_str = json.dumps(schema, default=str)
+        return truncate_string_to_tokens(results_str, config.token_limit) if config.token_limit else results_str
+
+    @mcp.tool()
+    async def read_neo4j_cypher(
+        query: str = Field(..., description='The Cypher query to execute.'),
+        params: dict[str, Any] = Field(dict(), description='Query parameters.'),
+    ) -> str:
+        """Execute a read Cypher query on the neo4j database."""
+
+        if is_write_query(query):
+            raise ValueError('Only MATCH queries are allowed for read-query')
+
+        try:
+            # We use the 'neo4j_driver' passed into create_mcp_server
+            query_obj = Query(query, timeout=float(config.neo4j_read_timeout))
+            results = await neo4j_driver.execute_query(
+                query_obj,
+                parameters_=params,
+                routing_control=RoutingControl.READ,
+                database_='neo4j',
+                result_transformer_=lambda r: r.data(),
+            )
+            sanitized = [value_sanitize(el) for el in results]
+            res_str = json.dumps(sanitized, default=str)
+
+            if config.token_limit:
+                res_str = truncate_string_to_tokens(res_str, config.token_limit)
+
+            return res_str
+
+        except Neo4jError as e:
+            raise ToolError(f'Neo4j Error: {e}\n{query}\n{params}')
+        except Exception as e:
+            raise ToolError(f'Error: {e}\n{query}\n{params}')
+
+    @mcp.tool()
+    async def write_neo4j_cypher(
+        query: str = Field(..., description='The Cypher query to execute.'),
+        params: dict[str, Any] = Field(dict(), description='Query parameters.'),
+    ) -> str:
+        """Execute a write Cypher query on the neo4j database."""
+
+        if not is_write_query(query):
+            raise ValueError('Only write queries are allowed for write-query')
+
+        try:
+            _, summary, _ = await neo4j_driver.execute_query(
+                query,
+                parameters_=params,
+                routing_control=RoutingControl.WRITE,
+                database_='neo4j',
+            )
+            return json.dumps(summary.counters.__dict__, default=str)
+
+        except Neo4jError as e:
+            raise ToolError(f'Neo4j Error: {e}\n{query}\n{params}')
+        except Exception as e:
+            raise ToolError(f'Error: {e}\n{query}\n{params}')
+
+    return mcp
 
 
-@mcp.tool()
-def list_iyp_node_types() -> list[NodeType]:
-    """List all node types in Internet Yellow Pages."""
-    return [node_type for node_type in node_types.values()]
+async def main():
 
+    db_url = 'bolt://iyp:7687'
+    auth = ('neo4j', 'password')
 
-@mcp.tool()
-def list_iyp_relationship_types() -> list[RelationshipType]:
-    """List all relationship types in Internet Yellow Pages."""
-    return [rel_type for rel_type in rel_types.values()]
+    parser = argparse.ArgumentParser(description='MCP Neo4j Server')
+    parser.add_argument('--port', type=int, default=config.port)
+    parser.add_argument('--sample-size', type=int, default=config.sample_size)
+    parser.add_argument('--neo4j-read-timeout', type=int, default=config.neo4j_read_timeout)
+    parser.add_argument('--token-limit', type=int, default=config.token_limit)
 
+    args = parser.parse_args()
 
-# General templated resource access
-# Not discoverable by clients, but callable by an LLM if wrapped in a tool
-@mcp.resource('dataset://{reference_name}')
-def get_iyp_dataset_documentation(reference_name: str) -> DatasetFull:
-    """Get complete documentation of a dataset associated to `reference_name` in
-    Internet Yellow Pages."""
-    return datasets[reference_name]
+    config.port = args.port
+    config.sample_size = args.sample_size
+    config.neo4j_read_timeout = args.neo4j_read_timeout
+    config.token_limit = args.token_limit
 
+    logging.info(f'Starting server with config {config}')
 
-@mcp.resource('node-type://{name}')
-def get_iyp_node_type_documentation(name: str) -> NodeType:
-    """Get complete documentation of a node type associated to `name` in Internet Yellow
-    Pages."""
-    return node_types[name]
+    logger.info(f'Connecting to Neo4j at {db_url}...')
 
+    async with AsyncGraphDatabase.driver(db_url, auth=auth) as driver:
 
-@mcp.resource('relationship-type://{name}')
-def get_iyp_relationship_type_documentation(name: str) -> RelationshipType:
-    """Get complete documentation of a relationship type associated to `name` in
-    Internet Yellow Pages."""
-    return rel_types[name]
+        try:
+            await driver.verify_connectivity()
+            logger.info('Neo4j connectivity verified.')
+        except Exception as e:
+            logger.error(f'Failed to connect to Neo4j: {e}')
+            return
 
+        logger.info('Retrieving schema from IYP...')
+        try:
+            schema = await retrieve_schema(driver, sample_size=config.sample_size)
+            logger.info('Schema retrieved successfully.')
+        except Exception as e:
+            logger.error(f'Failed to retrieve schema: {e}')
+            schema = {}
 
-# Wrap general templated resource access in a tool.
-# LLM can decide himself to fetch a resource
-scheme2getter = {
-    'dataset': get_iyp_dataset_documentation,
-    'node-type': get_iyp_node_type_documentation,
-    'relationship-type': get_iyp_relationship_type_documentation,
-}
+        mcp = create_mcp_server(driver, schema)
 
+        logger.info(f'Starting MCP Server on port {config.port}')
 
-@mcp.tool()
-def get_iyp_resource(
-    scheme: Literal['dataset', 'node-type', 'relationship-type'] = Field(
-        description='The scheme to access the resource.',
-    ),
-    name: str = Field(
-        description='Unique identifier of the resource (`reference_name` for datasets, `name` otherwise)'
-    ),
-):
-    """Get the Internet Yellow Pages documentation associated to the resource."""
-
-    if scheme not in scheme2getter:
-        return {
-            'error': (f"Unknown or unsupported resource URI scheme: '{scheme}://'. "
-                      "Only 'dataset://', 'node-type://' and relationship-type:// are supported."),
-            'status': 400,
-        }
-
-    try:
-        resource_data = scheme2getter[scheme](name)
-
-        return resource_data
-
-    except ValueError as e:
-        # Handle the specific error raised by the getter (e.g., resource not found)
-        return {'error': str(e), 'status': 404}
-    except Exception as e:
-        # General error handling
-        return {
-            'error': f'An unexpected error occurred while fetching dataset: {e}',
-            'status': 500,
-        }
-
-
-# Non-templated resource access
-# Resources are registered one by one to make them discoverable by MCP clients
-def register_dataset_resource(reference_name: str, dataset: DatasetFull):
-    # Create a specific URI for this dataset
-    uri = f'dataset://{reference_name}'
-
-    dynamic_description = f'Returns documentation of the {dataset.name} dataset.'
-
-    def get_dataset() -> DatasetFull:
-        return dataset
-
-    get_dataset.__doc__ = dynamic_description
-    mcp.resource(uri)(get_dataset)
-
-
-for reference_name, dataset in datasets.items():
-    register_dataset_resource(reference_name, dataset)
-
-
-def register_node_type_resource(name: str, node_type: NodeType):
-    uri = f'node-type://{name}'
-
-    dynamic_description = f'Returns documentation of the {name} node type'
-
-    def get_node_type() -> NodeType:
-        return node_type
-
-    get_node_type.__doc__ = dynamic_description
-    mcp.resource(uri)(get_node_type)
-
-
-for name, node_type in node_types.items():
-    register_node_type_resource(name, node_type)
-
-
-def register_relationship_type_resource(name: str, rel_type: RelationshipType):
-    uri = f'relationship-type://{name}'
-
-    dynamic_description = f'Returns documentation of the {name} relation type'
-
-    def get_relationship_type() -> RelationshipType:
-        return rel_type
-
-    get_relationship_type.__doc__ = dynamic_description
-    mcp.resource(uri)(get_relationship_type)
-
-
-for name, rel_type in rel_types.items():
-    register_relationship_type_resource(name, rel_type)
-
+        await mcp.run_http_async(host='0.0.0.0', port=config.port)
 
 if __name__ == '__main__':
-    mcp.run(transport='streamable-http')
+    import sys
+    FORMAT = '%(asctime)s %(levelname)s %(message)s'
+    logging.basicConfig(
+        format=FORMAT,
+        handlers=[
+            logging.StreamHandler(sys.stdout),
+        ],
+        level=logging.INFO,
+        datefmt='%Y-%m-%d %H:%M:%S',
+    )
+    asyncio.run(main())

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -27,7 +27,7 @@ import json
 import logging
 from typing import Any, Literal
 
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 from neo4j import AsyncDriver, AsyncGraphDatabase, Query, RoutingControl
 from neo4j.exceptions import Neo4jError
@@ -204,7 +204,7 @@ def create_mcp_server(neo4j_driver: AsyncDriver, schema: dict):
     # Use `include_node_types` to project the schema onto a smaller, relevant
     # subgraph, as the full schema is often too large to process.
     @mcp.tool()
-    async def get_neo4j_schema_projected(include_node_types: list[str] = Field(
+    async def get_neo4j_schema_projected(ctx: Context, include_node_types: list[str] = Field(
         description='A list of node types to include in the returned schema.'),
         include_relationship_types: list[str] = Field(
         description='An optional list of relationship types to include in the returned schema.',
@@ -251,20 +251,40 @@ def create_mcp_server(neo4j_driver: AsyncDriver, schema: dict):
             projected_schema[key] = new_entry
 
         results_str = json.dumps(projected_schema, default=str)
-        return truncate_string_to_tokens(results_str, config.token_limit) if config.token_limit else results_str
+        if not config.token_limit:
+            return results_str
+
+        truncated, is_truncated = truncate_string_to_tokens(results_str, config.token_limit)
+        if is_truncated:
+            await ctx.warning('Output was truncated due to token limit.')
+            return ('<tool_warning>Output was truncated due to token limit.'
+                    'Consider refining your query.</tool_warning>\n') + truncated
+        else:
+            return truncated
 
     # Version withouth node types filtering
     # advantage: less opinionated, less steps
     # disadvantage: context (around 30k)
+
     @mcp.tool()
-    async def get_neo4j_schema() -> str:
+    async def get_neo4j_schema(ctx: Context) -> str:
         """Returns the neo4j schema, including node types, their properties, and
         relationship types."""
         results_str = json.dumps(schema, default=str)
-        return truncate_string_to_tokens(results_str, config.token_limit) if config.token_limit else results_str
+        if not config.token_limit:
+            return results_str
+
+        truncated, is_truncated = truncate_string_to_tokens(results_str, config.token_limit)
+        if is_truncated:
+            await ctx.warning('Output was truncated due to token limit.')
+            return ('<tool_warning>Output was truncated due to token limit.'
+                    'Consider projecting the schema with `get_neo4j_schema_projected`.</tool_warning>\n') + truncated
+        else:
+            return truncated
 
     @mcp.tool()
     async def read_neo4j_cypher(
+        ctx: Context,
         query: str = Field(..., description='The Cypher query to execute.'),
         params: dict[str, Any] = Field(dict(), description='Query parameters.'),
     ) -> str:
@@ -284,12 +304,17 @@ def create_mcp_server(neo4j_driver: AsyncDriver, schema: dict):
                 result_transformer_=lambda r: r.data(),
             )
             sanitized = [value_sanitize(el) for el in results]
-            res_str = json.dumps(sanitized, default=str)
+            results_str = json.dumps(sanitized, default=str)
+            if not config.token_limit:
+                return results_str
 
-            if config.token_limit:
-                res_str = truncate_string_to_tokens(res_str, config.token_limit)
-
-            return res_str
+            truncated, is_truncated = truncate_string_to_tokens(results_str, config.token_limit)
+            if is_truncated:
+                await ctx.warning('Output was truncated due to token limit.')
+                return ('<tool_warning>Output was truncated due to token limit.'
+                        'Consider refining your query.</tool_warning>\n') + truncated
+            else:
+                return truncated
 
         except Neo4jError as e:
             raise ToolError(f'Neo4j Error: {e}\n{query}\n{params}')

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -53,7 +53,7 @@ class ServerConfig(BaseModel):
     neo4j_read_timeout: int = Field(default=60, description='Timemout for Neo4j read in seconds (default 60)')
     token_limit: int | None = Field(default=None, description='GPT token limit per response (default None)')
     port: int = Field(default=8010)
-    sample_size: int = Field(default=5000, description='Sample size used when querying the schema at server startup')
+    sample_size: int = Field(default=1000, description='Sample size used when querying the schema at server startup')
 
 
 config = ServerConfig()

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -29,7 +29,7 @@ from typing import Any, Literal
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
-from neo4j import AsyncGraphDatabase, Query, RoutingControl
+from neo4j import AsyncDriver, AsyncGraphDatabase, Query, RoutingControl
 from neo4j.exceptions import Neo4jError
 from pydantic import BaseModel, Field
 
@@ -38,8 +38,7 @@ from mcp_server.documentation.models import (DatasetBase, DatasetFull,
 from mcp_server.documentation.parsers import (parse_datasets, parse_node_types,
                                               parse_relationship_types)
 from mcp_server.mcp_neo4j.schema import retrieve_schema
-from mcp_server.mcp_neo4j.utils import (is_write_query,
-                                        truncate_string_to_tokens,
+from mcp_server.mcp_neo4j.utils import (truncate_string_to_tokens,
                                         value_sanitize)
 
 # Setup Logging
@@ -63,9 +62,21 @@ node_types = {node_type.name: node_type for node_type in parse_node_types()}
 rel_types = {rel_type.name: rel_type for rel_type in parse_relationship_types()}
 
 
+async def _is_write_query(query: str, driver: AsyncDriver, database: str = 'neo4j') -> bool:
+    """Check if the query is a write query by running EXPLAIN and inspecting the query
+    type."""
+    explain_query = 'EXPLAIN ' + query
+    _, summary, _ = await driver.execute_query(
+        query_=explain_query,
+        database_=database,
+    )
+    # query_type is 'r', 'w', 'rw', or 's'; anything containing 'w' is a write
+    return 'w' in (summary.query_type or '')
+
+
 # Server factory function following neo4j structure
 # Not an expert but apparently needed for async event context
-def create_mcp_server(neo4j_driver, schema):
+def create_mcp_server(neo4j_driver: AsyncDriver, schema: dict):
     """Creates the FastMCP server instance with all tools registered.
 
     We pass the 'neo4j_driver' and 'schema' in as arguments so the tools can close over
@@ -87,7 +98,7 @@ def create_mcp_server(neo4j_driver, schema):
         instructions=instructions
     )
 
-    # Part 1: documentation tool
+    # Part 1: documentation tools
 
     @mcp.tool()
     async def list_iyp_datasets() -> list[DatasetBase]:
@@ -259,7 +270,7 @@ def create_mcp_server(neo4j_driver, schema):
     ) -> str:
         """Execute a read Cypher query on the neo4j database."""
 
-        if is_write_query(query):
+        if await _is_write_query(query, driver=neo4j_driver):
             raise ValueError('Only MATCH queries are allowed for read-query')
 
         try:
@@ -292,7 +303,7 @@ def create_mcp_server(neo4j_driver, schema):
     ) -> str:
         """Execute a write Cypher query on the neo4j database."""
 
-        if not is_write_query(query):
+        if not await _is_write_query(query, driver=neo4j_driver):
             raise ValueError('Only write queries are allowed for write-query')
 
         try:


### PR DESCRIPTION
This PR reduces the prohibitive size of the schema produced by the MCP server by removing non-essential verbosity.

The size is reduced from 180K tokens (which exceeds gpt-oss-120b’s 128k context limit) to 40k, which is still significant.
Therefore an alternate tool `get_neo4j_schema_projected` is also provided to project the schema to node type / relationship type of interest.

Instead of using the neo4j docker image, a custom version is implemented (adaptation of their MIT-licensed code).
Therefore the mcp servers for both the doc and querying IYP are now merged in a single one.

## Description

- Custom version of `mcp_neo4j_cypher` instead of using neo4j's docker image:
	- Retrieve the schema once when the MCP server starts, instead of every time the LLM queries the server
	- Reduce schema verbosity from 180k to 40k (remove property constraints (existence, indexed, array) and non essential fields like reference_time, reference_url). I could go down to 28k by removing the types
	- Strip out unused features of neo4j's implementation (stdio / sse transport)
	- Add a new tool `get_schema_projected` to get a small projected schema on only specific node or relationship types. Great for reducing the context, also has the advantage of forcing the LLM to read the doc before requesting the schema
- As a result, the two MCP servers `iyp_doc` and `mcp_neo4j` are now merged into a single one
- Now that IYP has APOC, custom profile `mcp` and instance `iyp_apoc` are removed 
- Async makes the code more complicated, with the MCP server now nested in a factory function `create_mcp_server`. This is done like this in the [neo4j implementation](https://github.com/neo4j-contrib/mcp-neo4j/tree/main/servers/mcp-neo4j-cypher)
- Use [fastmcp](https://github.com/jlowin/fastmcp) instead of [python mcp sdk](https://github.com/modelcontextprotocol/python-sdk) because it has a better documentation and it is actively developed (mcp sdk is actually fastmcp version 1.0)

## Motivation and Context

- The original Neo4j implementation queries the schema from the Neo4j instance every time an LLM requests the schema, which takes too much time (few minutes) for IYP.
- The schema returned by `apoc.meta.schema` is too verbose, with a size of 180k gpt4 token. It causes apps to crash and confusion for LLMs. For reference, gpt-oss-120b max input tokens is 128k.

## How Has This Been Tested?

Tested with the example mcp client, npx mcp inspector and Claude.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.

